### PR TITLE
Switch packages for Ubuntu & macOS to use tar.gz format instead of zip

### DIFF
--- a/azure-pipelines/templates/build-job.yml
+++ b/azure-pipelines/templates/build-job.yml
@@ -14,16 +14,8 @@ jobs:
       filePath: './builders/build-node.ps1'
       arguments: '-Version $(Version) -Platform $(Platform) -Architecture $(Architecture)'
 
-  - task: ArchiveFiles@2
-    displayName: 'Archive artifact'
-    inputs:
-      rootFolderOrFile: '$(Build.BinariesDirectory)'
-      archiveType: zip
-      includeRootFolder: false
-      archiveFile: '$(Build.ArtifactStagingDirectory)/node-$(Version)-$(Platform)-$(Architecture).zip'
-
   - task: PublishPipelineArtifact@1
     displayName: 'Publish Artifact: Node.js $(Version)'
     inputs:
-      targetPath: '$(Build.ArtifactStagingDirectory)/node-$(Version)-$(Platform)-$(Architecture).zip' 
+      targetPath: '$(Build.ArtifactStagingDirectory)' 
       artifactName: 'node-$(Version)-$(Platform)-$(Architecture)'

--- a/azure-pipelines/templates/test-job.yml
+++ b/azure-pipelines/templates/test-job.yml
@@ -8,7 +8,7 @@ jobs:
     submodules: true
 
   - task: PowerShell@2
-    displayName: Fully cleanup the toolcache directory
+    displayName: Fully cleanup the toolcache directory before testing
     inputs:
       TargetType: inline
       script: |

--- a/azure-pipelines/templates/test-job.yml
+++ b/azure-pipelines/templates/test-job.yml
@@ -25,7 +25,7 @@ jobs:
 
   - task: ExtractFiles@1
     inputs:
-      archiveFilePatterns: '$(Build.ArtifactStagingDirectory)/node-$(Version)-$(Platform)-$(Architecture).zip'
+      archiveFilePatterns: '$(Build.ArtifactStagingDirectory)/node-$(Version)-$(Platform)-$(Architecture).*'
       destinationFolder: $(Build.BinariesDirectory)
       cleanDestinationFolder: false
 

--- a/azure-pipelines/templates/test-job.yml
+++ b/azure-pipelines/templates/test-job.yml
@@ -34,6 +34,8 @@ jobs:
     inputs:
       targetType: inline
       script: |
+        $pwd
+        Get-ChildItem
         if ("$(Platform)" -match 'win32') { powershell ./setup.ps1 } else { sh ./setup.sh }
       workingDirectory: '$(Build.BinariesDirectory)'
 

--- a/azure-pipelines/templates/test-job.yml
+++ b/azure-pipelines/templates/test-job.yml
@@ -34,8 +34,6 @@ jobs:
     inputs:
       targetType: inline
       script: |
-        $pwd
-        Get-ChildItem
         if ("$(Platform)" -match 'win32') { powershell ./setup.ps1 } else { sh ./setup.sh }
       workingDirectory: '$(Build.BinariesDirectory)'
 

--- a/builders/nix-node-builder.psm1
+++ b/builders/nix-node-builder.psm1
@@ -27,7 +27,7 @@ class NixNodeBuilder : NodeBuilder {
     ) : Base($version, $platform, $architecture) {
         $this.InstallationTemplateName = "nix-setup-template.sh"
         $this.InstallationScriptName = "setup.sh"
-        $this.OutputArtifactName = "tool.tar.gz"
+        $this.OutputArtifactName = "node-$Version-$Platform-$Architecture.tar.gz"
     }
 
     [uri] GetBinariesUri() {
@@ -41,7 +41,7 @@ class NixNodeBuilder : NodeBuilder {
     }
 
     [void] ExtractBinaries($archivePath) {
-        Extract-TarArchive -ArchivePath $archivePath -OutputDirectory $this.ArtifactLocation
+        Extract-TarArchive -ArchivePath $archivePath -OutputDirectory $this.WorkFolderLocation
     }
 
     [void] CreateInstallationScript() {
@@ -50,7 +50,7 @@ class NixNodeBuilder : NodeBuilder {
         Create Node.js artifact installation script based on template specified in InstallationTemplateName property.
         #>
 
-        $installationScriptLocation = New-Item -Path $this.ArtifactLocation -Name $this.InstallationScriptName -ItemType File
+        $installationScriptLocation = New-Item -Path $this.WorkFolderLocation -Name $this.InstallationScriptName -ItemType File
         $installationTemplateLocation = Join-Path -Path $this.InstallationTemplatesLocation -ChildPath $this.InstallationTemplateName
 
         $installationTemplateContent = Get-Content -Path $installationTemplateLocation -Raw
@@ -58,5 +58,10 @@ class NixNodeBuilder : NodeBuilder {
         $installationTemplateContent | Out-File -FilePath $installationScriptLocation
 
         Write-Debug "Done; Installation script location: $installationScriptLocation)"
+    }
+
+    [void] ArchiveArtifact() {
+        $OutputPath = Join-Path $this.ArtifactFolderLocation $this.OutputArtifactName
+        Create-TarArchive -SourceFolder $this.WorkFolderLocation -ArchivePath $OutputPath
     }
 }

--- a/builders/node-builder.psm1
+++ b/builders/node-builder.psm1
@@ -30,7 +30,8 @@ class NodeBuilder {
     [string] $Platform
     [string] $Architecture
     [string] $TempFolderLocation
-    [string] $ArtifactLocation
+    [string] $WorkFolderLocation
+    [string] $ArtifactFolderLocation
     [string] $InstallationTemplatesLocation
 
     NodeBuilder ([version] $version, [string] $platform, [string] $architecture) {
@@ -38,8 +39,10 @@ class NodeBuilder {
         $this.Platform = $platform
         $this.Architecture = $architecture
 
-        $this.ArtifactLocation = $env:BUILD_BINARIESDIRECTORY
-        $this.TempFolderLocation = $env:BUILD_STAGINGDIRECTORY
+        $this.TempFolderLocation = [IO.Path]::GetTempPath()
+        $this.WorkFolderLocation = $env:BUILD_BINARIESDIRECTORY
+        $this.ArtifactFolderLocation = $env:BUILD_STAGINGDIRECTORY
+        
 
         $this.InstallationTemplatesLocation = Join-Path -Path $PSScriptRoot -ChildPath "../installers"
     }
@@ -89,5 +92,8 @@ class NodeBuilder {
 
         Write-Host "Create installation script..."
         $this.CreateInstallationScript()
+
+        Write-Host "Archive artifact"
+        $this.ArchiveArtifact()
     }
 }

--- a/helpers/nix-helpers.psm1
+++ b/helpers/nix-helpers.psm1
@@ -25,5 +25,5 @@ function Create-TarArchive {
 
     $CompressionArgument = If ([string]::IsNullOrWhiteSpace($CompressionType)) { "" } else { "--${CompressionType}" }
 
-    tar -c $CompressionArgument -f $ArchivePath "$SourceFolder\*.*"
+    tar -c $CompressionArgument -f $ArchivePath "$SourceFolder/*.*"
 }

--- a/helpers/nix-helpers.psm1
+++ b/helpers/nix-helpers.psm1
@@ -12,5 +12,18 @@ function Extract-TarArchive {
 
     Write-Debug "Extract $ArchivePath to $OutputDirectory"
     tar -C $OutputDirectory -xzf $ArchivePath --strip 1
+}
 
+function Create-TarArchive {
+    param(
+        [Parameter(Mandatory=$true)]
+        [String]$SourceFolder,
+        [Parameter(Mandatory=$true)]
+        [String]$ArchivePath,
+        [string]$CompressionType = "gz"
+    )
+
+    $CompressionArgument = If ([string]::IsNullOrWhiteSpace($CompressionType)) { "" } else { "--${CompressionType}" }
+
+    tar -c $CompressionArgument -f $ArchivePath "$SourceFolder\*.*"
 }

--- a/helpers/nix-helpers.psm1
+++ b/helpers/nix-helpers.psm1
@@ -25,6 +25,8 @@ function Create-TarArchive {
 
     $CompressionTypeArgument = If ([string]::IsNullOrWhiteSpace($CompressionType)) { "" } else { "--${CompressionType}" }
 
-    Write-Debug "tar -c $CompressionTypeArgument -f $ArchivePath $SourceFolder"
-    tar -c $CompressionTypeArgument -f $ArchivePath $SourceFolder
+    Push-Location $SourceFolder
+    Write-Debug "tar -c $CompressionTypeArgument -f $ArchivePath ."
+    tar -c $CompressionTypeArgument -f $ArchivePath .
+    Pop-Location
 }

--- a/helpers/nix-helpers.psm1
+++ b/helpers/nix-helpers.psm1
@@ -23,7 +23,8 @@ function Create-TarArchive {
         [string]$CompressionType = "gz"
     )
 
-    $CompressionArgument = If ([string]::IsNullOrWhiteSpace($CompressionType)) { "" } else { "--${CompressionType}" }
+    $CompressionTypeArgument = If ([string]::IsNullOrWhiteSpace($CompressionType)) { "" } else { "--${CompressionType}" }
 
-    tar -c $CompressionArgument -f $ArchivePath "$SourceFolder/*.*"
+    Write-Debug "tar -c $CompressionTypeArgument -f $ArchivePath $SourceFolder"
+    tar -c $CompressionTypeArgument -f $ArchivePath $SourceFolder
 }

--- a/helpers/win-helpers.psm1
+++ b/helpers/win-helpers.psm1
@@ -29,6 +29,6 @@ function Create-SevenZipArchive {
     
     Push-Location $SourceFolder
     Write-Debug "7z a $ArchiveTypeArgument $CompressionLevelArgument $ArchivePath @$SourceFolder"
-    7z a $ArchiveTypeArgument $CompressionLevelArgument $ArchivePath $SourceFolder
+    7z a $ArchiveTypeArgument $CompressionLevelArgument $ArchivePath $SourceFolder\*
     Pop-Location
 }

--- a/helpers/win-helpers.psm1
+++ b/helpers/win-helpers.psm1
@@ -2,7 +2,7 @@
 .SYNOPSIS
 Unpack *.7z file
 #>
-function Extract-7ZipArchive {
+function Extract-SevenZipArchive {
     param(
         [Parameter(Mandatory=$true)]
         [String]$ArchivePath,
@@ -12,4 +12,18 @@ function Extract-7ZipArchive {
 
     Write-Debug "Extract $ArchivePath to $OutputDirectory"
     7z x $ArchivePath -o"$OutputDirectory" -y | Out-Null
+}
+
+function Create-SevenZipArchive {
+    param(
+        [Parameter(Mandatory=$true)]
+        [String]$SourceFolder,
+        [Parameter(Mandatory=$true)]
+        [String]$ArchivePath,
+        [String]$ArchiveType = "zip"
+    )
+
+    $ArchiveTypeArgument = "-t${ArchiveType}"
+
+    7z a $ArchiveTypeArgument $ArchivePath "$SourceFolder\*.*" -r
 }

--- a/helpers/win-helpers.psm1
+++ b/helpers/win-helpers.psm1
@@ -25,5 +25,7 @@ function Create-SevenZipArchive {
 
     $ArchiveTypeArgument = "-t${ArchiveType}"
 
-    7z a $ArchiveTypeArgument $ArchivePath "$SourceFolder\*.*" -r
+    Push-Location $SourceFolder
+    7z a $ArchiveTypeArgument $ArchivePath *.* -r
+    Pop-Location
 }

--- a/helpers/win-helpers.psm1
+++ b/helpers/win-helpers.psm1
@@ -29,6 +29,6 @@ function Create-SevenZipArchive {
     
     Push-Location $SourceFolder
     Write-Debug "7z a $ArchiveTypeArgument $CompressionLevelArgument $ArchivePath @$SourceFolder"
-    7z a $ArchiveTypeArgument $CompressionLevelArgument $ArchivePath @$SourceFolder
+    7z a $ArchiveTypeArgument $CompressionLevelArgument $ArchivePath $SourceFolder
     Pop-Location
 }

--- a/helpers/win-helpers.psm1
+++ b/helpers/win-helpers.psm1
@@ -20,12 +20,15 @@ function Create-SevenZipArchive {
         [String]$SourceFolder,
         [Parameter(Mandatory=$true)]
         [String]$ArchivePath,
-        [String]$ArchiveType = "zip"
+        [String]$ArchiveType = "zip",
+        [String]$CompressionLevel = 5
     )
 
     $ArchiveTypeArgument = "-t${ArchiveType}"
-
+    $CompressionLevelArgument = "-mx=${CompressionLevel}"
+    
     Push-Location $SourceFolder
-    7z a $ArchiveTypeArgument $ArchivePath *.* -r
+    Write-Debug "7z a $ArchiveTypeArgument $CompressionLevelArgument $ArchivePath @$SourceFolder"
+    7z a $ArchiveTypeArgument $CompressionLevelArgument $ArchivePath @$SourceFolder
     Pop-Location
 }


### PR DESCRIPTION
Switch to using `tar.gz` format for Ubuntu and macOS systems because it is much more common on nix systems which is important in container scenarios