### PR TITLE
[versions-manifest] Update for release from 04/30/2020

### DIFF
--- a/versions-manifest.json
+++ b/versions-manifest.json
@@ -1,5 +1,30 @@
 [
   {
+    "version": "14.1.0",
+    "stable": true,
+    "release_url": "https://github.com/actions/node-versions/releases/tag/14.1.0-20200430.1",
+    "files": [
+      {
+        "filename": "node-14.1.0-darwin-x64.tar.gz",
+        "arch": "x64",
+        "platform": "darwin",
+        "download_url": "https://github.com/actions/node-versions/releases/download/14.1.0-20200430.1/node-14.1.0-darwin-x64.tar.gz"
+      },
+      {
+        "filename": "node-14.1.0-linux-x64.tar.gz",
+        "arch": "x64",
+        "platform": "linux",
+        "download_url": "https://github.com/actions/node-versions/releases/download/14.1.0-20200430.1/node-14.1.0-linux-x64.tar.gz"
+      },
+      {
+        "filename": "node-14.1.0-win32-x64.zip",
+        "arch": "x64",
+        "platform": "win32",
+        "download_url": "https://github.com/actions/node-versions/releases/download/14.1.0-20200430.1/node-14.1.0-win32-x64.zip"
+      }
+    ]
+  },
+  {
     "version": "14.0.0",
     "stable": true,
     "release_url": "https://github.com/actions/node-versions/releases/tag/14.0.0-20200423.30",
@@ -50,6 +75,31 @@
     ]
   },
   {
+    "version": "12.16.3",
+    "stable": true,
+    "release_url": "https://github.com/actions/node-versions/releases/tag/12.16.3-20200430.29",
+    "files": [
+      {
+        "filename": "node-12.16.3-darwin-x64.tar.gz",
+        "arch": "x64",
+        "platform": "darwin",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.16.3-20200430.29/node-12.16.3-darwin-x64.tar.gz"
+      },
+      {
+        "filename": "node-12.16.3-linux-x64.tar.gz",
+        "arch": "x64",
+        "platform": "linux",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.16.3-20200430.29/node-12.16.3-linux-x64.tar.gz"
+      },
+      {
+        "filename": "node-12.16.3-win32-x64.zip",
+        "arch": "x64",
+        "platform": "win32",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.16.3-20200430.29/node-12.16.3-win32-x64.zip"
+      }
+    ]
+  },
+  {
     "version": "12.16.2",
     "stable": true,
     "release_url": "https://github.com/actions/node-versions/releases/tag/12.16.2-20200423.28",
@@ -71,6 +121,606 @@
         "arch": "x64",
         "platform": "win32",
         "download_url": "https://github.com/actions/node-versions/releases/download/12.16.2-20200423.28/node-12.16.2-win32-x64.zip"
+      }
+    ]
+  },
+  {
+    "version": "12.16.1",
+    "stable": true,
+    "release_url": "https://github.com/actions/node-versions/releases/tag/12.16.1-20200430.14",
+    "files": [
+      {
+        "filename": "node-12.16.1-darwin-x64.tar.gz",
+        "arch": "x64",
+        "platform": "darwin",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.16.1-20200430.14/node-12.16.1-darwin-x64.tar.gz"
+      },
+      {
+        "filename": "node-12.16.1-linux-x64.tar.gz",
+        "arch": "x64",
+        "platform": "linux",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.16.1-20200430.14/node-12.16.1-linux-x64.tar.gz"
+      },
+      {
+        "filename": "node-12.16.1-win32-x64.zip",
+        "arch": "x64",
+        "platform": "win32",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.16.1-20200430.14/node-12.16.1-win32-x64.zip"
+      }
+    ]
+  },
+  {
+    "version": "12.16.0",
+    "stable": true,
+    "release_url": "https://github.com/actions/node-versions/releases/tag/12.16.0-20200430.13",
+    "files": [
+      {
+        "filename": "node-12.16.0-darwin-x64.tar.gz",
+        "arch": "x64",
+        "platform": "darwin",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.16.0-20200430.13/node-12.16.0-darwin-x64.tar.gz"
+      },
+      {
+        "filename": "node-12.16.0-linux-x64.tar.gz",
+        "arch": "x64",
+        "platform": "linux",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.16.0-20200430.13/node-12.16.0-linux-x64.tar.gz"
+      },
+      {
+        "filename": "node-12.16.0-win32-x64.zip",
+        "arch": "x64",
+        "platform": "win32",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.16.0-20200430.13/node-12.16.0-win32-x64.zip"
+      }
+    ]
+  },
+  {
+    "version": "12.15.0",
+    "stable": true,
+    "release_url": "https://github.com/actions/node-versions/releases/tag/12.15.0-20200430.12",
+    "files": [
+      {
+        "filename": "node-12.15.0-darwin-x64.tar.gz",
+        "arch": "x64",
+        "platform": "darwin",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.15.0-20200430.12/node-12.15.0-darwin-x64.tar.gz"
+      },
+      {
+        "filename": "node-12.15.0-linux-x64.tar.gz",
+        "arch": "x64",
+        "platform": "linux",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.15.0-20200430.12/node-12.15.0-linux-x64.tar.gz"
+      },
+      {
+        "filename": "node-12.15.0-win32-x64.zip",
+        "arch": "x64",
+        "platform": "win32",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.15.0-20200430.12/node-12.15.0-win32-x64.zip"
+      }
+    ]
+  },
+  {
+    "version": "12.14.1",
+    "stable": true,
+    "release_url": "https://github.com/actions/node-versions/releases/tag/12.14.1-20200430.11",
+    "files": [
+      {
+        "filename": "node-12.14.1-darwin-x64.tar.gz",
+        "arch": "x64",
+        "platform": "darwin",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.14.1-20200430.11/node-12.14.1-darwin-x64.tar.gz"
+      },
+      {
+        "filename": "node-12.14.1-linux-x64.tar.gz",
+        "arch": "x64",
+        "platform": "linux",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.14.1-20200430.11/node-12.14.1-linux-x64.tar.gz"
+      },
+      {
+        "filename": "node-12.14.1-win32-x64.zip",
+        "arch": "x64",
+        "platform": "win32",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.14.1-20200430.11/node-12.14.1-win32-x64.zip"
+      }
+    ]
+  },
+  {
+    "version": "12.14.0",
+    "stable": true,
+    "release_url": "https://github.com/actions/node-versions/releases/tag/12.14.0-20200430.10",
+    "files": [
+      {
+        "filename": "node-12.14.0-darwin-x64.tar.gz",
+        "arch": "x64",
+        "platform": "darwin",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.14.0-20200430.10/node-12.14.0-darwin-x64.tar.gz"
+      },
+      {
+        "filename": "node-12.14.0-linux-x64.tar.gz",
+        "arch": "x64",
+        "platform": "linux",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.14.0-20200430.10/node-12.14.0-linux-x64.tar.gz"
+      },
+      {
+        "filename": "node-12.14.0-win32-x64.zip",
+        "arch": "x64",
+        "platform": "win32",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.14.0-20200430.10/node-12.14.0-win32-x64.zip"
+      }
+    ]
+  },
+  {
+    "version": "12.13.1",
+    "stable": true,
+    "release_url": "https://github.com/actions/node-versions/releases/tag/12.13.1-20200430.9",
+    "files": [
+      {
+        "filename": "node-12.13.1-darwin-x64.tar.gz",
+        "arch": "x64",
+        "platform": "darwin",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.13.1-20200430.9/node-12.13.1-darwin-x64.tar.gz"
+      },
+      {
+        "filename": "node-12.13.1-linux-x64.tar.gz",
+        "arch": "x64",
+        "platform": "linux",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.13.1-20200430.9/node-12.13.1-linux-x64.tar.gz"
+      },
+      {
+        "filename": "node-12.13.1-win32-x64.zip",
+        "arch": "x64",
+        "platform": "win32",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.13.1-20200430.9/node-12.13.1-win32-x64.zip"
+      }
+    ]
+  },
+  {
+    "version": "12.13.0",
+    "stable": true,
+    "release_url": "https://github.com/actions/node-versions/releases/tag/12.13.0-20200430.8",
+    "files": [
+      {
+        "filename": "node-12.13.0-darwin-x64.tar.gz",
+        "arch": "x64",
+        "platform": "darwin",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.13.0-20200430.8/node-12.13.0-darwin-x64.tar.gz"
+      },
+      {
+        "filename": "node-12.13.0-linux-x64.tar.gz",
+        "arch": "x64",
+        "platform": "linux",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.13.0-20200430.8/node-12.13.0-linux-x64.tar.gz"
+      },
+      {
+        "filename": "node-12.13.0-win32-x64.zip",
+        "arch": "x64",
+        "platform": "win32",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.13.0-20200430.8/node-12.13.0-win32-x64.zip"
+      }
+    ]
+  },
+  {
+    "version": "12.12.0",
+    "stable": true,
+    "release_url": "https://github.com/actions/node-versions/releases/tag/12.12.0-20200430.7",
+    "files": [
+      {
+        "filename": "node-12.12.0-darwin-x64.tar.gz",
+        "arch": "x64",
+        "platform": "darwin",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.12.0-20200430.7/node-12.12.0-darwin-x64.tar.gz"
+      },
+      {
+        "filename": "node-12.12.0-linux-x64.tar.gz",
+        "arch": "x64",
+        "platform": "linux",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.12.0-20200430.7/node-12.12.0-linux-x64.tar.gz"
+      },
+      {
+        "filename": "node-12.12.0-win32-x64.zip",
+        "arch": "x64",
+        "platform": "win32",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.12.0-20200430.7/node-12.12.0-win32-x64.zip"
+      }
+    ]
+  },
+  {
+    "version": "12.11.1",
+    "stable": true,
+    "release_url": "https://github.com/actions/node-versions/releases/tag/12.11.1-20200430.6",
+    "files": [
+      {
+        "filename": "node-12.11.1-darwin-x64.tar.gz",
+        "arch": "x64",
+        "platform": "darwin",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.11.1-20200430.6/node-12.11.1-darwin-x64.tar.gz"
+      },
+      {
+        "filename": "node-12.11.1-linux-x64.tar.gz",
+        "arch": "x64",
+        "platform": "linux",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.11.1-20200430.6/node-12.11.1-linux-x64.tar.gz"
+      },
+      {
+        "filename": "node-12.11.1-win32-x64.zip",
+        "arch": "x64",
+        "platform": "win32",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.11.1-20200430.6/node-12.11.1-win32-x64.zip"
+      }
+    ]
+  },
+  {
+    "version": "12.11.0",
+    "stable": true,
+    "release_url": "https://github.com/actions/node-versions/releases/tag/12.11.0-20200430.5",
+    "files": [
+      {
+        "filename": "node-12.11.0-darwin-x64.tar.gz",
+        "arch": "x64",
+        "platform": "darwin",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.11.0-20200430.5/node-12.11.0-darwin-x64.tar.gz"
+      },
+      {
+        "filename": "node-12.11.0-linux-x64.tar.gz",
+        "arch": "x64",
+        "platform": "linux",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.11.0-20200430.5/node-12.11.0-linux-x64.tar.gz"
+      },
+      {
+        "filename": "node-12.11.0-win32-x64.zip",
+        "arch": "x64",
+        "platform": "win32",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.11.0-20200430.5/node-12.11.0-win32-x64.zip"
+      }
+    ]
+  },
+  {
+    "version": "12.10.0",
+    "stable": true,
+    "release_url": "https://github.com/actions/node-versions/releases/tag/12.10.0-20200430.4",
+    "files": [
+      {
+        "filename": "node-12.10.0-darwin-x64.tar.gz",
+        "arch": "x64",
+        "platform": "darwin",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.10.0-20200430.4/node-12.10.0-darwin-x64.tar.gz"
+      },
+      {
+        "filename": "node-12.10.0-linux-x64.tar.gz",
+        "arch": "x64",
+        "platform": "linux",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.10.0-20200430.4/node-12.10.0-linux-x64.tar.gz"
+      },
+      {
+        "filename": "node-12.10.0-win32-x64.zip",
+        "arch": "x64",
+        "platform": "win32",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.10.0-20200430.4/node-12.10.0-win32-x64.zip"
+      }
+    ]
+  },
+  {
+    "version": "12.9.1",
+    "stable": true,
+    "release_url": "https://github.com/actions/node-versions/releases/tag/12.9.1-20200430.26",
+    "files": [
+      {
+        "filename": "node-12.9.1-darwin-x64.tar.gz",
+        "arch": "x64",
+        "platform": "darwin",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.9.1-20200430.26/node-12.9.1-darwin-x64.tar.gz"
+      },
+      {
+        "filename": "node-12.9.1-linux-x64.tar.gz",
+        "arch": "x64",
+        "platform": "linux",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.9.1-20200430.26/node-12.9.1-linux-x64.tar.gz"
+      },
+      {
+        "filename": "node-12.9.1-win32-x64.zip",
+        "arch": "x64",
+        "platform": "win32",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.9.1-20200430.26/node-12.9.1-win32-x64.zip"
+      }
+    ]
+  },
+  {
+    "version": "12.9.0",
+    "stable": true,
+    "release_url": "https://github.com/actions/node-versions/releases/tag/12.9.0-20200430.25",
+    "files": [
+      {
+        "filename": "node-12.9.0-darwin-x64.tar.gz",
+        "arch": "x64",
+        "platform": "darwin",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.9.0-20200430.25/node-12.9.0-darwin-x64.tar.gz"
+      },
+      {
+        "filename": "node-12.9.0-linux-x64.tar.gz",
+        "arch": "x64",
+        "platform": "linux",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.9.0-20200430.25/node-12.9.0-linux-x64.tar.gz"
+      },
+      {
+        "filename": "node-12.9.0-win32-x64.zip",
+        "arch": "x64",
+        "platform": "win32",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.9.0-20200430.25/node-12.9.0-win32-x64.zip"
+      }
+    ]
+  },
+  {
+    "version": "12.8.1",
+    "stable": true,
+    "release_url": "https://github.com/actions/node-versions/releases/tag/12.8.1-20200430.24",
+    "files": [
+      {
+        "filename": "node-12.8.1-darwin-x64.tar.gz",
+        "arch": "x64",
+        "platform": "darwin",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.8.1-20200430.24/node-12.8.1-darwin-x64.tar.gz"
+      },
+      {
+        "filename": "node-12.8.1-linux-x64.tar.gz",
+        "arch": "x64",
+        "platform": "linux",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.8.1-20200430.24/node-12.8.1-linux-x64.tar.gz"
+      },
+      {
+        "filename": "node-12.8.1-win32-x64.zip",
+        "arch": "x64",
+        "platform": "win32",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.8.1-20200430.24/node-12.8.1-win32-x64.zip"
+      }
+    ]
+  },
+  {
+    "version": "12.8.0",
+    "stable": true,
+    "release_url": "https://github.com/actions/node-versions/releases/tag/12.8.0-20200430.23",
+    "files": [
+      {
+        "filename": "node-12.8.0-darwin-x64.tar.gz",
+        "arch": "x64",
+        "platform": "darwin",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.8.0-20200430.23/node-12.8.0-darwin-x64.tar.gz"
+      },
+      {
+        "filename": "node-12.8.0-linux-x64.tar.gz",
+        "arch": "x64",
+        "platform": "linux",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.8.0-20200430.23/node-12.8.0-linux-x64.tar.gz"
+      },
+      {
+        "filename": "node-12.8.0-win32-x64.zip",
+        "arch": "x64",
+        "platform": "win32",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.8.0-20200430.23/node-12.8.0-win32-x64.zip"
+      }
+    ]
+  },
+  {
+    "version": "12.7.0",
+    "stable": true,
+    "release_url": "https://github.com/actions/node-versions/releases/tag/12.7.0-20200430.22",
+    "files": [
+      {
+        "filename": "node-12.7.0-darwin-x64.tar.gz",
+        "arch": "x64",
+        "platform": "darwin",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.7.0-20200430.22/node-12.7.0-darwin-x64.tar.gz"
+      },
+      {
+        "filename": "node-12.7.0-linux-x64.tar.gz",
+        "arch": "x64",
+        "platform": "linux",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.7.0-20200430.22/node-12.7.0-linux-x64.tar.gz"
+      },
+      {
+        "filename": "node-12.7.0-win32-x64.zip",
+        "arch": "x64",
+        "platform": "win32",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.7.0-20200430.22/node-12.7.0-win32-x64.zip"
+      }
+    ]
+  },
+  {
+    "version": "12.6.0",
+    "stable": true,
+    "release_url": "https://github.com/actions/node-versions/releases/tag/12.6.0-20200430.21",
+    "files": [
+      {
+        "filename": "node-12.6.0-darwin-x64.tar.gz",
+        "arch": "x64",
+        "platform": "darwin",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.6.0-20200430.21/node-12.6.0-darwin-x64.tar.gz"
+      },
+      {
+        "filename": "node-12.6.0-linux-x64.tar.gz",
+        "arch": "x64",
+        "platform": "linux",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.6.0-20200430.21/node-12.6.0-linux-x64.tar.gz"
+      },
+      {
+        "filename": "node-12.6.0-win32-x64.zip",
+        "arch": "x64",
+        "platform": "win32",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.6.0-20200430.21/node-12.6.0-win32-x64.zip"
+      }
+    ]
+  },
+  {
+    "version": "12.5.0",
+    "stable": true,
+    "release_url": "https://github.com/actions/node-versions/releases/tag/12.5.0-20200430.20",
+    "files": [
+      {
+        "filename": "node-12.5.0-darwin-x64.tar.gz",
+        "arch": "x64",
+        "platform": "darwin",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.5.0-20200430.20/node-12.5.0-darwin-x64.tar.gz"
+      },
+      {
+        "filename": "node-12.5.0-linux-x64.tar.gz",
+        "arch": "x64",
+        "platform": "linux",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.5.0-20200430.20/node-12.5.0-linux-x64.tar.gz"
+      },
+      {
+        "filename": "node-12.5.0-win32-x64.zip",
+        "arch": "x64",
+        "platform": "win32",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.5.0-20200430.20/node-12.5.0-win32-x64.zip"
+      }
+    ]
+  },
+  {
+    "version": "12.4.0",
+    "stable": true,
+    "release_url": "https://github.com/actions/node-versions/releases/tag/12.4.0-20200430.19",
+    "files": [
+      {
+        "filename": "node-12.4.0-darwin-x64.tar.gz",
+        "arch": "x64",
+        "platform": "darwin",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.4.0-20200430.19/node-12.4.0-darwin-x64.tar.gz"
+      },
+      {
+        "filename": "node-12.4.0-linux-x64.tar.gz",
+        "arch": "x64",
+        "platform": "linux",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.4.0-20200430.19/node-12.4.0-linux-x64.tar.gz"
+      },
+      {
+        "filename": "node-12.4.0-win32-x64.zip",
+        "arch": "x64",
+        "platform": "win32",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.4.0-20200430.19/node-12.4.0-win32-x64.zip"
+      }
+    ]
+  },
+  {
+    "version": "12.3.1",
+    "stable": true,
+    "release_url": "https://github.com/actions/node-versions/releases/tag/12.3.1-20200430.18",
+    "files": [
+      {
+        "filename": "node-12.3.1-darwin-x64.tar.gz",
+        "arch": "x64",
+        "platform": "darwin",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.3.1-20200430.18/node-12.3.1-darwin-x64.tar.gz"
+      },
+      {
+        "filename": "node-12.3.1-linux-x64.tar.gz",
+        "arch": "x64",
+        "platform": "linux",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.3.1-20200430.18/node-12.3.1-linux-x64.tar.gz"
+      },
+      {
+        "filename": "node-12.3.1-win32-x64.zip",
+        "arch": "x64",
+        "platform": "win32",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.3.1-20200430.18/node-12.3.1-win32-x64.zip"
+      }
+    ]
+  },
+  {
+    "version": "12.3.0",
+    "stable": true,
+    "release_url": "https://github.com/actions/node-versions/releases/tag/12.3.0-20200430.17",
+    "files": [
+      {
+        "filename": "node-12.3.0-darwin-x64.tar.gz",
+        "arch": "x64",
+        "platform": "darwin",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.3.0-20200430.17/node-12.3.0-darwin-x64.tar.gz"
+      },
+      {
+        "filename": "node-12.3.0-linux-x64.tar.gz",
+        "arch": "x64",
+        "platform": "linux",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.3.0-20200430.17/node-12.3.0-linux-x64.tar.gz"
+      },
+      {
+        "filename": "node-12.3.0-win32-x64.zip",
+        "arch": "x64",
+        "platform": "win32",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.3.0-20200430.17/node-12.3.0-win32-x64.zip"
+      }
+    ]
+  },
+  {
+    "version": "12.2.0",
+    "stable": true,
+    "release_url": "https://github.com/actions/node-versions/releases/tag/12.2.0-20200430.16",
+    "files": [
+      {
+        "filename": "node-12.2.0-darwin-x64.tar.gz",
+        "arch": "x64",
+        "platform": "darwin",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.2.0-20200430.16/node-12.2.0-darwin-x64.tar.gz"
+      },
+      {
+        "filename": "node-12.2.0-linux-x64.tar.gz",
+        "arch": "x64",
+        "platform": "linux",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.2.0-20200430.16/node-12.2.0-linux-x64.tar.gz"
+      },
+      {
+        "filename": "node-12.2.0-win32-x64.zip",
+        "arch": "x64",
+        "platform": "win32",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.2.0-20200430.16/node-12.2.0-win32-x64.zip"
+      }
+    ]
+  },
+  {
+    "version": "12.1.0",
+    "stable": true,
+    "release_url": "https://github.com/actions/node-versions/releases/tag/12.1.0-20200430.3",
+    "files": [
+      {
+        "filename": "node-12.1.0-darwin-x64.tar.gz",
+        "arch": "x64",
+        "platform": "darwin",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.1.0-20200430.3/node-12.1.0-darwin-x64.tar.gz"
+      },
+      {
+        "filename": "node-12.1.0-linux-x64.tar.gz",
+        "arch": "x64",
+        "platform": "linux",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.1.0-20200430.3/node-12.1.0-linux-x64.tar.gz"
+      },
+      {
+        "filename": "node-12.1.0-win32-x64.zip",
+        "arch": "x64",
+        "platform": "win32",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.1.0-20200430.3/node-12.1.0-win32-x64.zip"
+      }
+    ]
+  },
+  {
+    "version": "12.0.0",
+    "stable": true,
+    "release_url": "https://github.com/actions/node-versions/releases/tag/12.0.0-20200430.28",
+    "files": [
+      {
+        "filename": "node-12.0.0-darwin-x64.tar.gz",
+        "arch": "x64",
+        "platform": "darwin",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.0.0-20200430.28/node-12.0.0-darwin-x64.tar.gz"
+      },
+      {
+        "filename": "node-12.0.0-linux-x64.tar.gz",
+        "arch": "x64",
+        "platform": "linux",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.0.0-20200430.28/node-12.0.0-linux-x64.tar.gz"
+      },
+      {
+        "filename": "node-12.0.0-win32-x64.zip",
+        "arch": "x64",
+        "platform": "win32",
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.0.0-20200430.28/node-12.0.0-win32-x64.zip"
       }
     ]
   },


### PR DESCRIPTION
Update versions-manifest.json for release from 04/30/2020

We published versions from `12.0.0` to `12.16.1` and `12.16.3`, `14.1.0`