### PR TITLE
Increase the number of releases received by API

### DIFF
--- a/helpers/github/github-api.psm1
+++ b/helpers/github/github-api.psm1
@@ -60,9 +60,26 @@ class GitHubApi
         return $this.InvokeRestMethod($url, 'Post', $null, $requestBody)
     }
 
-    [object] GetGitHubReleases(){
+    [array] GetReleases(){
         $url = "releases"
-        return $this.InvokeRestMethod($url, 'GET', $null, $null)
+        $releases = @()
+        $pageNumber = 1
+        $releaseNumberLimit = 10000
+
+        while ($releases.Count -le $releaseNumberLimit)
+        {
+            $requestParams = "page=${pageNumber}&per_page=100"
+            [array] $response = $this.InvokeRestMethod($url, 'GET', $requestParams, $null)
+            
+            if ($response.Count -eq 0) {
+                break
+            } else {
+                $releases += $response
+                $pageNumber++
+            }
+        }
+
+        return $releases
     }
 
     [string] hidden BuildUrl([string]$Url, [string]$RequestParams) {

--- a/helpers/packages-generation/generate-versions-manifest.ps1
+++ b/helpers/packages-generation/generate-versions-manifest.ps1
@@ -153,6 +153,6 @@ function Build-VersionsManifest {
 }
 
 $gitHubApi = Get-GitHubApi -AccountName $GitHubRepositoryOwner -ProjectName $GitHubRepositoryName -AccessToken $GitHubAccessToken
-$releases = $gitHubApi.GetGitHubReleases()
+$releases = $gitHubApi.GetReleases()
 $versionIndex = Build-VersionsManifest $releases
 $versionIndex | ConvertTo-Json -Depth 5 | Out-File $OutputFile -Encoding UTF8NoBOM -Force


### PR DESCRIPTION
GitHub API returns 30 releases by default. In scope of this PR we've increased the limit to 10000.