### PR TITLE
[versions-manifest] Update for release from 05/04/2020

### DIFF
--- a/versions-manifest.json
+++ b/versions-manifest.json
@@ -2,2475 +2,2500 @@
   {
     "version": "14.1.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/14.1.0-20200430.1",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/14.1.0-20200504.98",
     "files": [
       {
         "filename": "node-14.1.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/14.1.0-20200430.1/node-14.1.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/14.1.0-20200504.98/node-14.1.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-14.1.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/14.1.0-20200430.1/node-14.1.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/14.1.0-20200504.98/node-14.1.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-14.1.0-win32-x64.zip",
+        "filename": "node-14.1.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/14.1.0-20200430.1/node-14.1.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/14.1.0-20200504.98/node-14.1.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "14.0.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/14.0.0-20200423.30",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/14.0.0-20200504.97",
     "files": [
       {
         "filename": "node-14.0.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/14.0.0-20200423.30/node-14.0.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/14.0.0-20200504.97/node-14.0.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-14.0.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/14.0.0-20200423.30/node-14.0.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/14.0.0-20200504.97/node-14.0.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-14.0.0-win32-x64.zip",
+        "filename": "node-14.0.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/14.0.0-20200423.30/node-14.0.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/14.0.0-20200504.97/node-14.0.0-win32-x64.7z"
+      }
+    ]
+  },
+  {
+    "version": "13.14.0",
+    "stable": true,
+    "release_url": "https://github.com/actions/node-versions/releases/tag/13.14.0-20200504.102",
+    "files": [
+      {
+        "filename": "node-13.14.0-darwin-x64.tar.gz",
+        "arch": "x64",
+        "platform": "darwin",
+        "download_url": "https://github.com/actions/node-versions/releases/download/13.14.0-20200504.102/node-13.14.0-darwin-x64.tar.gz"
+      },
+      {
+        "filename": "node-13.14.0-linux-x64.tar.gz",
+        "arch": "x64",
+        "platform": "linux",
+        "download_url": "https://github.com/actions/node-versions/releases/download/13.14.0-20200504.102/node-13.14.0-linux-x64.tar.gz"
+      },
+      {
+        "filename": "node-13.14.0-win32-x64.7z",
+        "arch": "x64",
+        "platform": "win32",
+        "download_url": "https://github.com/actions/node-versions/releases/download/13.14.0-20200504.102/node-13.14.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "13.13.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/13.13.0-20200423.29",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/13.13.0-20200504.100",
     "files": [
       {
         "filename": "node-13.13.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/13.13.0-20200423.29/node-13.13.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/13.13.0-20200504.100/node-13.13.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-13.13.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/13.13.0-20200423.29/node-13.13.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/13.13.0-20200504.100/node-13.13.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-13.13.0-win32-x64.zip",
+        "filename": "node-13.13.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/13.13.0-20200423.29/node-13.13.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/13.13.0-20200504.100/node-13.13.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "12.16.3",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/12.16.3-20200430.29",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/12.16.3-20200504.85",
     "files": [
       {
         "filename": "node-12.16.3-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.16.3-20200430.29/node-12.16.3-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.16.3-20200504.85/node-12.16.3-darwin-x64.tar.gz"
       },
       {
         "filename": "node-12.16.3-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.16.3-20200430.29/node-12.16.3-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.16.3-20200504.85/node-12.16.3-linux-x64.tar.gz"
       },
       {
-        "filename": "node-12.16.3-win32-x64.zip",
+        "filename": "node-12.16.3-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.16.3-20200430.29/node-12.16.3-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.16.3-20200504.85/node-12.16.3-win32-x64.7z"
       }
     ]
   },
   {
     "version": "12.16.2",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/12.16.2-20200423.28",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/12.16.2-20200504.84",
     "files": [
       {
         "filename": "node-12.16.2-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.16.2-20200423.28/node-12.16.2-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.16.2-20200504.84/node-12.16.2-darwin-x64.tar.gz"
       },
       {
         "filename": "node-12.16.2-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.16.2-20200423.28/node-12.16.2-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.16.2-20200504.84/node-12.16.2-linux-x64.tar.gz"
       },
       {
-        "filename": "node-12.16.2-win32-x64.zip",
+        "filename": "node-12.16.2-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.16.2-20200423.28/node-12.16.2-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.16.2-20200504.84/node-12.16.2-win32-x64.7z"
       }
     ]
   },
   {
     "version": "12.16.1",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/12.16.1-20200430.14",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/12.16.1-20200504.83",
     "files": [
       {
         "filename": "node-12.16.1-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.16.1-20200430.14/node-12.16.1-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.16.1-20200504.83/node-12.16.1-darwin-x64.tar.gz"
       },
       {
         "filename": "node-12.16.1-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.16.1-20200430.14/node-12.16.1-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.16.1-20200504.83/node-12.16.1-linux-x64.tar.gz"
       },
       {
-        "filename": "node-12.16.1-win32-x64.zip",
+        "filename": "node-12.16.1-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.16.1-20200430.14/node-12.16.1-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.16.1-20200504.83/node-12.16.1-win32-x64.7z"
       }
     ]
   },
   {
     "version": "12.16.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/12.16.0-20200430.13",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/12.16.0-20200504.82",
     "files": [
       {
         "filename": "node-12.16.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.16.0-20200430.13/node-12.16.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.16.0-20200504.82/node-12.16.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-12.16.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.16.0-20200430.13/node-12.16.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.16.0-20200504.82/node-12.16.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-12.16.0-win32-x64.zip",
+        "filename": "node-12.16.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.16.0-20200430.13/node-12.16.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.16.0-20200504.82/node-12.16.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "12.15.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/12.15.0-20200430.12",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/12.15.0-20200504.81",
     "files": [
       {
         "filename": "node-12.15.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.15.0-20200430.12/node-12.15.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.15.0-20200504.81/node-12.15.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-12.15.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.15.0-20200430.12/node-12.15.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.15.0-20200504.81/node-12.15.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-12.15.0-win32-x64.zip",
+        "filename": "node-12.15.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.15.0-20200430.12/node-12.15.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.15.0-20200504.81/node-12.15.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "12.14.1",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/12.14.1-20200430.11",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/12.14.1-20200504.80",
     "files": [
       {
         "filename": "node-12.14.1-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.14.1-20200430.11/node-12.14.1-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.14.1-20200504.80/node-12.14.1-darwin-x64.tar.gz"
       },
       {
         "filename": "node-12.14.1-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.14.1-20200430.11/node-12.14.1-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.14.1-20200504.80/node-12.14.1-linux-x64.tar.gz"
       },
       {
-        "filename": "node-12.14.1-win32-x64.zip",
+        "filename": "node-12.14.1-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.14.1-20200430.11/node-12.14.1-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.14.1-20200504.80/node-12.14.1-win32-x64.7z"
       }
     ]
   },
   {
     "version": "12.14.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/12.14.0-20200430.10",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/12.14.0-20200504.79",
     "files": [
       {
         "filename": "node-12.14.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.14.0-20200430.10/node-12.14.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.14.0-20200504.79/node-12.14.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-12.14.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.14.0-20200430.10/node-12.14.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.14.0-20200504.79/node-12.14.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-12.14.0-win32-x64.zip",
+        "filename": "node-12.14.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.14.0-20200430.10/node-12.14.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.14.0-20200504.79/node-12.14.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "12.13.1",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/12.13.1-20200430.9",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/12.13.1-20200504.78",
     "files": [
       {
         "filename": "node-12.13.1-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.13.1-20200430.9/node-12.13.1-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.13.1-20200504.78/node-12.13.1-darwin-x64.tar.gz"
       },
       {
         "filename": "node-12.13.1-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.13.1-20200430.9/node-12.13.1-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.13.1-20200504.78/node-12.13.1-linux-x64.tar.gz"
       },
       {
-        "filename": "node-12.13.1-win32-x64.zip",
+        "filename": "node-12.13.1-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.13.1-20200430.9/node-12.13.1-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.13.1-20200504.78/node-12.13.1-win32-x64.7z"
       }
     ]
   },
   {
     "version": "12.13.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/12.13.0-20200430.8",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/12.13.0-20200504.77",
     "files": [
       {
         "filename": "node-12.13.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.13.0-20200430.8/node-12.13.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.13.0-20200504.77/node-12.13.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-12.13.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.13.0-20200430.8/node-12.13.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.13.0-20200504.77/node-12.13.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-12.13.0-win32-x64.zip",
+        "filename": "node-12.13.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.13.0-20200430.8/node-12.13.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.13.0-20200504.77/node-12.13.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "12.12.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/12.12.0-20200430.7",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/12.12.0-20200504.76",
     "files": [
       {
         "filename": "node-12.12.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.12.0-20200430.7/node-12.12.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.12.0-20200504.76/node-12.12.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-12.12.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.12.0-20200430.7/node-12.12.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.12.0-20200504.76/node-12.12.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-12.12.0-win32-x64.zip",
+        "filename": "node-12.12.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.12.0-20200430.7/node-12.12.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.12.0-20200504.76/node-12.12.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "12.11.1",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/12.11.1-20200430.6",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/12.11.1-20200504.75",
     "files": [
       {
         "filename": "node-12.11.1-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.11.1-20200430.6/node-12.11.1-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.11.1-20200504.75/node-12.11.1-darwin-x64.tar.gz"
       },
       {
         "filename": "node-12.11.1-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.11.1-20200430.6/node-12.11.1-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.11.1-20200504.75/node-12.11.1-linux-x64.tar.gz"
       },
       {
-        "filename": "node-12.11.1-win32-x64.zip",
+        "filename": "node-12.11.1-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.11.1-20200430.6/node-12.11.1-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.11.1-20200504.75/node-12.11.1-win32-x64.7z"
       }
     ]
   },
   {
     "version": "12.11.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/12.11.0-20200430.5",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/12.11.0-20200504.74",
     "files": [
       {
         "filename": "node-12.11.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.11.0-20200430.5/node-12.11.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.11.0-20200504.74/node-12.11.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-12.11.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.11.0-20200430.5/node-12.11.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.11.0-20200504.74/node-12.11.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-12.11.0-win32-x64.zip",
+        "filename": "node-12.11.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.11.0-20200430.5/node-12.11.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.11.0-20200504.74/node-12.11.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "12.10.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/12.10.0-20200430.4",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/12.10.0-20200504.73",
     "files": [
       {
         "filename": "node-12.10.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.10.0-20200430.4/node-12.10.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.10.0-20200504.73/node-12.10.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-12.10.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.10.0-20200430.4/node-12.10.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.10.0-20200504.73/node-12.10.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-12.10.0-win32-x64.zip",
+        "filename": "node-12.10.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.10.0-20200430.4/node-12.10.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.10.0-20200504.73/node-12.10.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "12.9.1",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/12.9.1-20200430.26",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/12.9.1-20200504.96",
     "files": [
       {
         "filename": "node-12.9.1-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.9.1-20200430.26/node-12.9.1-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.9.1-20200504.96/node-12.9.1-darwin-x64.tar.gz"
       },
       {
         "filename": "node-12.9.1-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.9.1-20200430.26/node-12.9.1-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.9.1-20200504.96/node-12.9.1-linux-x64.tar.gz"
       },
       {
-        "filename": "node-12.9.1-win32-x64.zip",
+        "filename": "node-12.9.1-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.9.1-20200430.26/node-12.9.1-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.9.1-20200504.96/node-12.9.1-win32-x64.7z"
       }
     ]
   },
   {
     "version": "12.9.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/12.9.0-20200430.25",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/12.9.0-20200504.95",
     "files": [
       {
         "filename": "node-12.9.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.9.0-20200430.25/node-12.9.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.9.0-20200504.95/node-12.9.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-12.9.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.9.0-20200430.25/node-12.9.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.9.0-20200504.95/node-12.9.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-12.9.0-win32-x64.zip",
+        "filename": "node-12.9.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.9.0-20200430.25/node-12.9.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.9.0-20200504.95/node-12.9.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "12.8.1",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/12.8.1-20200430.24",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/12.8.1-20200504.94",
     "files": [
       {
         "filename": "node-12.8.1-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.8.1-20200430.24/node-12.8.1-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.8.1-20200504.94/node-12.8.1-darwin-x64.tar.gz"
       },
       {
         "filename": "node-12.8.1-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.8.1-20200430.24/node-12.8.1-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.8.1-20200504.94/node-12.8.1-linux-x64.tar.gz"
       },
       {
-        "filename": "node-12.8.1-win32-x64.zip",
+        "filename": "node-12.8.1-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.8.1-20200430.24/node-12.8.1-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.8.1-20200504.94/node-12.8.1-win32-x64.7z"
       }
     ]
   },
   {
     "version": "12.8.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/12.8.0-20200430.23",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/12.8.0-20200504.93",
     "files": [
       {
         "filename": "node-12.8.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.8.0-20200430.23/node-12.8.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.8.0-20200504.93/node-12.8.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-12.8.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.8.0-20200430.23/node-12.8.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.8.0-20200504.93/node-12.8.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-12.8.0-win32-x64.zip",
+        "filename": "node-12.8.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.8.0-20200430.23/node-12.8.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.8.0-20200504.93/node-12.8.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "12.7.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/12.7.0-20200430.22",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/12.7.0-20200504.92",
     "files": [
       {
         "filename": "node-12.7.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.7.0-20200430.22/node-12.7.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.7.0-20200504.92/node-12.7.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-12.7.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.7.0-20200430.22/node-12.7.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.7.0-20200504.92/node-12.7.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-12.7.0-win32-x64.zip",
+        "filename": "node-12.7.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.7.0-20200430.22/node-12.7.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.7.0-20200504.92/node-12.7.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "12.6.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/12.6.0-20200430.21",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/12.6.0-20200504.91",
     "files": [
       {
         "filename": "node-12.6.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.6.0-20200430.21/node-12.6.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.6.0-20200504.91/node-12.6.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-12.6.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.6.0-20200430.21/node-12.6.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.6.0-20200504.91/node-12.6.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-12.6.0-win32-x64.zip",
+        "filename": "node-12.6.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.6.0-20200430.21/node-12.6.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.6.0-20200504.91/node-12.6.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "12.5.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/12.5.0-20200430.20",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/12.5.0-20200504.90",
     "files": [
       {
         "filename": "node-12.5.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.5.0-20200430.20/node-12.5.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.5.0-20200504.90/node-12.5.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-12.5.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.5.0-20200430.20/node-12.5.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.5.0-20200504.90/node-12.5.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-12.5.0-win32-x64.zip",
+        "filename": "node-12.5.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.5.0-20200430.20/node-12.5.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.5.0-20200504.90/node-12.5.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "12.4.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/12.4.0-20200430.19",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/12.4.0-20200504.89",
     "files": [
       {
         "filename": "node-12.4.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.4.0-20200430.19/node-12.4.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.4.0-20200504.89/node-12.4.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-12.4.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.4.0-20200430.19/node-12.4.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.4.0-20200504.89/node-12.4.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-12.4.0-win32-x64.zip",
+        "filename": "node-12.4.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.4.0-20200430.19/node-12.4.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.4.0-20200504.89/node-12.4.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "12.3.1",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/12.3.1-20200430.18",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/12.3.1-20200504.88",
     "files": [
       {
         "filename": "node-12.3.1-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.3.1-20200430.18/node-12.3.1-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.3.1-20200504.88/node-12.3.1-darwin-x64.tar.gz"
       },
       {
         "filename": "node-12.3.1-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.3.1-20200430.18/node-12.3.1-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.3.1-20200504.88/node-12.3.1-linux-x64.tar.gz"
       },
       {
-        "filename": "node-12.3.1-win32-x64.zip",
+        "filename": "node-12.3.1-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.3.1-20200430.18/node-12.3.1-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.3.1-20200504.88/node-12.3.1-win32-x64.7z"
       }
     ]
   },
   {
     "version": "12.3.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/12.3.0-20200430.17",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/12.3.0-20200504.87",
     "files": [
       {
         "filename": "node-12.3.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.3.0-20200430.17/node-12.3.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.3.0-20200504.87/node-12.3.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-12.3.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.3.0-20200430.17/node-12.3.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.3.0-20200504.87/node-12.3.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-12.3.0-win32-x64.zip",
+        "filename": "node-12.3.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.3.0-20200430.17/node-12.3.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.3.0-20200504.87/node-12.3.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "12.2.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/12.2.0-20200430.16",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/12.2.0-20200504.86",
     "files": [
       {
         "filename": "node-12.2.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.2.0-20200430.16/node-12.2.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.2.0-20200504.86/node-12.2.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-12.2.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.2.0-20200430.16/node-12.2.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.2.0-20200504.86/node-12.2.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-12.2.0-win32-x64.zip",
+        "filename": "node-12.2.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.2.0-20200430.16/node-12.2.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.2.0-20200504.86/node-12.2.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "12.1.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/12.1.0-20200430.3",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/12.1.0-20200504.72",
     "files": [
       {
         "filename": "node-12.1.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.1.0-20200430.3/node-12.1.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.1.0-20200504.72/node-12.1.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-12.1.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.1.0-20200430.3/node-12.1.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.1.0-20200504.72/node-12.1.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-12.1.0-win32-x64.zip",
+        "filename": "node-12.1.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.1.0-20200430.3/node-12.1.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.1.0-20200504.72/node-12.1.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "12.0.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/12.0.0-20200430.28",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/12.0.0-20200504.71",
     "files": [
       {
         "filename": "node-12.0.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.0.0-20200430.28/node-12.0.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.0.0-20200504.71/node-12.0.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-12.0.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.0.0-20200430.28/node-12.0.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.0.0-20200504.71/node-12.0.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-12.0.0-win32-x64.zip",
+        "filename": "node-12.0.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/12.0.0-20200430.28/node-12.0.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/12.0.0-20200504.71/node-12.0.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "10.20.1",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/10.20.1-20200423.27",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/10.20.1-20200504.62",
     "files": [
       {
         "filename": "node-10.20.1-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.20.1-20200423.27/node-10.20.1-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.20.1-20200504.62/node-10.20.1-darwin-x64.tar.gz"
       },
       {
         "filename": "node-10.20.1-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.20.1-20200423.27/node-10.20.1-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.20.1-20200504.62/node-10.20.1-linux-x64.tar.gz"
       },
       {
-        "filename": "node-10.20.1-win32-x64.zip",
+        "filename": "node-10.20.1-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.20.1-20200423.27/node-10.20.1-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.20.1-20200504.62/node-10.20.1-win32-x64.7z"
       }
     ]
   },
   {
     "version": "10.20.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/10.20.0-20200430.54",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/10.20.0-20200504.61",
     "files": [
       {
         "filename": "node-10.20.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.20.0-20200430.54/node-10.20.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.20.0-20200504.61/node-10.20.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-10.20.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.20.0-20200430.54/node-10.20.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.20.0-20200504.61/node-10.20.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-10.20.0-win32-x64.zip",
+        "filename": "node-10.20.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.20.0-20200430.54/node-10.20.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.20.0-20200504.61/node-10.20.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "10.19.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/10.19.0-20200430.51",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/10.19.0-20200504.58",
     "files": [
       {
         "filename": "node-10.19.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.19.0-20200430.51/node-10.19.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.19.0-20200504.58/node-10.19.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-10.19.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.19.0-20200430.51/node-10.19.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.19.0-20200504.58/node-10.19.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-10.19.0-win32-x64.zip",
+        "filename": "node-10.19.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.19.0-20200430.51/node-10.19.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.19.0-20200504.58/node-10.19.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "10.18.1",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/10.18.1-20200430.50",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/10.18.1-20200504.57",
     "files": [
       {
         "filename": "node-10.18.1-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.18.1-20200430.50/node-10.18.1-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.18.1-20200504.57/node-10.18.1-darwin-x64.tar.gz"
       },
       {
         "filename": "node-10.18.1-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.18.1-20200430.50/node-10.18.1-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.18.1-20200504.57/node-10.18.1-linux-x64.tar.gz"
       },
       {
-        "filename": "node-10.18.1-win32-x64.zip",
+        "filename": "node-10.18.1-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.18.1-20200430.50/node-10.18.1-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.18.1-20200504.57/node-10.18.1-win32-x64.7z"
       }
     ]
   },
   {
     "version": "10.18.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/10.18.0-20200430.49",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/10.18.0-20200504.56",
     "files": [
       {
         "filename": "node-10.18.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.18.0-20200430.49/node-10.18.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.18.0-20200504.56/node-10.18.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-10.18.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.18.0-20200430.49/node-10.18.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.18.0-20200504.56/node-10.18.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-10.18.0-win32-x64.zip",
+        "filename": "node-10.18.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.18.0-20200430.49/node-10.18.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.18.0-20200504.56/node-10.18.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "10.17.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/10.17.0-20200430.48",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/10.17.0-20200504.55",
     "files": [
       {
         "filename": "node-10.17.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.17.0-20200430.48/node-10.17.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.17.0-20200504.55/node-10.17.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-10.17.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.17.0-20200430.48/node-10.17.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.17.0-20200504.55/node-10.17.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-10.17.0-win32-x64.zip",
+        "filename": "node-10.17.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.17.0-20200430.48/node-10.17.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.17.0-20200504.55/node-10.17.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "10.16.3",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/10.16.3-20200430.47",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/10.16.3-20200504.54",
     "files": [
       {
         "filename": "node-10.16.3-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.16.3-20200430.47/node-10.16.3-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.16.3-20200504.54/node-10.16.3-darwin-x64.tar.gz"
       },
       {
         "filename": "node-10.16.3-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.16.3-20200430.47/node-10.16.3-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.16.3-20200504.54/node-10.16.3-linux-x64.tar.gz"
       },
       {
-        "filename": "node-10.16.3-win32-x64.zip",
+        "filename": "node-10.16.3-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.16.3-20200430.47/node-10.16.3-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.16.3-20200504.54/node-10.16.3-win32-x64.7z"
       }
     ]
   },
   {
     "version": "10.16.2",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/10.16.2-20200430.46",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/10.16.2-20200504.53",
     "files": [
       {
         "filename": "node-10.16.2-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.16.2-20200430.46/node-10.16.2-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.16.2-20200504.53/node-10.16.2-darwin-x64.tar.gz"
       },
       {
         "filename": "node-10.16.2-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.16.2-20200430.46/node-10.16.2-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.16.2-20200504.53/node-10.16.2-linux-x64.tar.gz"
       },
       {
-        "filename": "node-10.16.2-win32-x64.zip",
+        "filename": "node-10.16.2-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.16.2-20200430.46/node-10.16.2-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.16.2-20200504.53/node-10.16.2-win32-x64.7z"
       }
     ]
   },
   {
     "version": "10.16.1",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/10.16.1-20200430.63",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/10.16.1-20200504.52",
     "files": [
       {
         "filename": "node-10.16.1-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.16.1-20200430.63/node-10.16.1-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.16.1-20200504.52/node-10.16.1-darwin-x64.tar.gz"
       },
       {
         "filename": "node-10.16.1-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.16.1-20200430.63/node-10.16.1-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.16.1-20200504.52/node-10.16.1-linux-x64.tar.gz"
       },
       {
-        "filename": "node-10.16.1-win32-x64.zip",
+        "filename": "node-10.16.1-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.16.1-20200430.63/node-10.16.1-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.16.1-20200504.52/node-10.16.1-win32-x64.7z"
       }
     ]
   },
   {
     "version": "10.16.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/10.16.0-20200430.44",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/10.16.0-20200504.51",
     "files": [
       {
         "filename": "node-10.16.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.16.0-20200430.44/node-10.16.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.16.0-20200504.51/node-10.16.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-10.16.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.16.0-20200430.44/node-10.16.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.16.0-20200504.51/node-10.16.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-10.16.0-win32-x64.zip",
+        "filename": "node-10.16.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.16.0-20200430.44/node-10.16.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.16.0-20200504.51/node-10.16.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "10.15.3",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/10.15.3-20200430.43",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/10.15.3-20200504.50",
     "files": [
       {
         "filename": "node-10.15.3-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.15.3-20200430.43/node-10.15.3-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.15.3-20200504.50/node-10.15.3-darwin-x64.tar.gz"
       },
       {
         "filename": "node-10.15.3-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.15.3-20200430.43/node-10.15.3-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.15.3-20200504.50/node-10.15.3-linux-x64.tar.gz"
       },
       {
-        "filename": "node-10.15.3-win32-x64.zip",
+        "filename": "node-10.15.3-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.15.3-20200430.43/node-10.15.3-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.15.3-20200504.50/node-10.15.3-win32-x64.7z"
       }
     ]
   },
   {
     "version": "10.15.2",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/10.15.2-20200430.42",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/10.15.2-20200504.49",
     "files": [
       {
         "filename": "node-10.15.2-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.15.2-20200430.42/node-10.15.2-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.15.2-20200504.49/node-10.15.2-darwin-x64.tar.gz"
       },
       {
         "filename": "node-10.15.2-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.15.2-20200430.42/node-10.15.2-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.15.2-20200504.49/node-10.15.2-linux-x64.tar.gz"
       },
       {
-        "filename": "node-10.15.2-win32-x64.zip",
+        "filename": "node-10.15.2-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.15.2-20200430.42/node-10.15.2-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.15.2-20200504.49/node-10.15.2-win32-x64.7z"
       }
     ]
   },
   {
     "version": "10.15.1",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/10.15.1-20200430.41",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/10.15.1-20200504.48",
     "files": [
       {
         "filename": "node-10.15.1-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.15.1-20200430.41/node-10.15.1-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.15.1-20200504.48/node-10.15.1-darwin-x64.tar.gz"
       },
       {
         "filename": "node-10.15.1-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.15.1-20200430.41/node-10.15.1-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.15.1-20200504.48/node-10.15.1-linux-x64.tar.gz"
       },
       {
-        "filename": "node-10.15.1-win32-x64.zip",
+        "filename": "node-10.15.1-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.15.1-20200430.41/node-10.15.1-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.15.1-20200504.48/node-10.15.1-win32-x64.7z"
       }
     ]
   },
   {
     "version": "10.15.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/10.15.0-20200430.40",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/10.15.0-20200504.47",
     "files": [
       {
         "filename": "node-10.15.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.15.0-20200430.40/node-10.15.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.15.0-20200504.47/node-10.15.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-10.15.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.15.0-20200430.40/node-10.15.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.15.0-20200504.47/node-10.15.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-10.15.0-win32-x64.zip",
+        "filename": "node-10.15.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.15.0-20200430.40/node-10.15.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.15.0-20200504.47/node-10.15.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "10.14.2",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/10.14.2-20200430.39",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/10.14.2-20200504.46",
     "files": [
       {
         "filename": "node-10.14.2-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.14.2-20200430.39/node-10.14.2-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.14.2-20200504.46/node-10.14.2-darwin-x64.tar.gz"
       },
       {
         "filename": "node-10.14.2-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.14.2-20200430.39/node-10.14.2-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.14.2-20200504.46/node-10.14.2-linux-x64.tar.gz"
       },
       {
-        "filename": "node-10.14.2-win32-x64.zip",
+        "filename": "node-10.14.2-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.14.2-20200430.39/node-10.14.2-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.14.2-20200504.46/node-10.14.2-win32-x64.7z"
       }
     ]
   },
   {
     "version": "10.14.1",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/10.14.1-20200430.38",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/10.14.1-20200504.45",
     "files": [
       {
         "filename": "node-10.14.1-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.14.1-20200430.38/node-10.14.1-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.14.1-20200504.45/node-10.14.1-darwin-x64.tar.gz"
       },
       {
         "filename": "node-10.14.1-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.14.1-20200430.38/node-10.14.1-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.14.1-20200504.45/node-10.14.1-linux-x64.tar.gz"
       },
       {
-        "filename": "node-10.14.1-win32-x64.zip",
+        "filename": "node-10.14.1-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.14.1-20200430.38/node-10.14.1-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.14.1-20200504.45/node-10.14.1-win32-x64.7z"
       }
     ]
   },
   {
     "version": "10.14.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/10.14.0-20200430.37",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/10.14.0-20200504.44",
     "files": [
       {
         "filename": "node-10.14.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.14.0-20200430.37/node-10.14.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.14.0-20200504.44/node-10.14.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-10.14.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.14.0-20200430.37/node-10.14.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.14.0-20200504.44/node-10.14.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-10.14.0-win32-x64.zip",
+        "filename": "node-10.14.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.14.0-20200430.37/node-10.14.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.14.0-20200504.44/node-10.14.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "10.13.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/10.13.0-20200430.36",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/10.13.0-20200504.43",
     "files": [
       {
         "filename": "node-10.13.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.13.0-20200430.36/node-10.13.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.13.0-20200504.43/node-10.13.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-10.13.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.13.0-20200430.36/node-10.13.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.13.0-20200504.43/node-10.13.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-10.13.0-win32-x64.zip",
+        "filename": "node-10.13.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.13.0-20200430.36/node-10.13.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.13.0-20200504.43/node-10.13.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "10.12.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/10.12.0-20200430.35",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/10.12.0-20200504.42",
     "files": [
       {
         "filename": "node-10.12.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.12.0-20200430.35/node-10.12.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.12.0-20200504.42/node-10.12.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-10.12.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.12.0-20200430.35/node-10.12.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.12.0-20200504.42/node-10.12.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-10.12.0-win32-x64.zip",
+        "filename": "node-10.12.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.12.0-20200430.35/node-10.12.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.12.0-20200504.42/node-10.12.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "10.11.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/10.11.0-20200430.34",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/10.11.0-20200504.41",
     "files": [
       {
         "filename": "node-10.11.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.11.0-20200430.34/node-10.11.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.11.0-20200504.41/node-10.11.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-10.11.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.11.0-20200430.34/node-10.11.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.11.0-20200504.41/node-10.11.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-10.11.0-win32-x64.zip",
+        "filename": "node-10.11.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.11.0-20200430.34/node-10.11.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.11.0-20200504.41/node-10.11.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "10.10.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/10.10.0-20200430.33",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/10.10.0-20200504.40",
     "files": [
       {
         "filename": "node-10.10.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.10.0-20200430.33/node-10.10.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.10.0-20200504.40/node-10.10.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-10.10.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.10.0-20200430.33/node-10.10.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.10.0-20200504.40/node-10.10.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-10.10.0-win32-x64.zip",
+        "filename": "node-10.10.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.10.0-20200430.33/node-10.10.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.10.0-20200504.40/node-10.10.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "10.9.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/10.9.0-20200430.62",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/10.9.0-20200504.70",
     "files": [
       {
         "filename": "node-10.9.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.9.0-20200430.62/node-10.9.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.9.0-20200504.70/node-10.9.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-10.9.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.9.0-20200430.62/node-10.9.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.9.0-20200504.70/node-10.9.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-10.9.0-win32-x64.zip",
+        "filename": "node-10.9.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.9.0-20200430.62/node-10.9.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.9.0-20200504.70/node-10.9.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "10.8.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/10.8.0-20200430.61",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/10.8.0-20200504.69",
     "files": [
       {
         "filename": "node-10.8.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.8.0-20200430.61/node-10.8.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.8.0-20200504.69/node-10.8.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-10.8.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.8.0-20200430.61/node-10.8.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.8.0-20200504.69/node-10.8.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-10.8.0-win32-x64.zip",
+        "filename": "node-10.8.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.8.0-20200430.61/node-10.8.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.8.0-20200504.69/node-10.8.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "10.7.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/10.7.0-20200430.60",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/10.7.0-20200504.68",
     "files": [
       {
         "filename": "node-10.7.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.7.0-20200430.60/node-10.7.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.7.0-20200504.68/node-10.7.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-10.7.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.7.0-20200430.60/node-10.7.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.7.0-20200504.68/node-10.7.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-10.7.0-win32-x64.zip",
+        "filename": "node-10.7.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.7.0-20200430.60/node-10.7.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.7.0-20200504.68/node-10.7.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "10.6.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/10.6.0-20200430.59",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/10.6.0-20200504.67",
     "files": [
       {
         "filename": "node-10.6.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.6.0-20200430.59/node-10.6.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.6.0-20200504.67/node-10.6.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-10.6.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.6.0-20200430.59/node-10.6.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.6.0-20200504.67/node-10.6.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-10.6.0-win32-x64.zip",
+        "filename": "node-10.6.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.6.0-20200430.59/node-10.6.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.6.0-20200504.67/node-10.6.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "10.5.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/10.5.0-20200430.58",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/10.5.0-20200504.66",
     "files": [
       {
         "filename": "node-10.5.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.5.0-20200430.58/node-10.5.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.5.0-20200504.66/node-10.5.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-10.5.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.5.0-20200430.58/node-10.5.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.5.0-20200504.66/node-10.5.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-10.5.0-win32-x64.zip",
+        "filename": "node-10.5.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.5.0-20200430.58/node-10.5.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.5.0-20200504.66/node-10.5.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "10.4.1",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/10.4.1-20200430.57",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/10.4.1-20200504.65",
     "files": [
       {
         "filename": "node-10.4.1-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.4.1-20200430.57/node-10.4.1-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.4.1-20200504.65/node-10.4.1-darwin-x64.tar.gz"
       },
       {
         "filename": "node-10.4.1-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.4.1-20200430.57/node-10.4.1-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.4.1-20200504.65/node-10.4.1-linux-x64.tar.gz"
       },
       {
-        "filename": "node-10.4.1-win32-x64.zip",
+        "filename": "node-10.4.1-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.4.1-20200430.57/node-10.4.1-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.4.1-20200504.65/node-10.4.1-win32-x64.7z"
       }
     ]
   },
   {
     "version": "10.4.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/10.4.0-20200430.56",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/10.4.0-20200504.64",
     "files": [
       {
         "filename": "node-10.4.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.4.0-20200430.56/node-10.4.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.4.0-20200504.64/node-10.4.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-10.4.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.4.0-20200430.56/node-10.4.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.4.0-20200504.64/node-10.4.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-10.4.0-win32-x64.zip",
+        "filename": "node-10.4.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.4.0-20200430.56/node-10.4.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.4.0-20200504.64/node-10.4.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "10.3.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/10.3.0-20200430.55",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/10.3.0-20200504.63",
     "files": [
       {
         "filename": "node-10.3.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.3.0-20200430.55/node-10.3.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.3.0-20200504.63/node-10.3.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-10.3.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.3.0-20200430.55/node-10.3.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.3.0-20200504.63/node-10.3.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-10.3.0-win32-x64.zip",
+        "filename": "node-10.3.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.3.0-20200430.55/node-10.3.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.3.0-20200504.63/node-10.3.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "10.2.1",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/10.2.1-20200430.53",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/10.2.1-20200504.60",
     "files": [
       {
         "filename": "node-10.2.1-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.2.1-20200430.53/node-10.2.1-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.2.1-20200504.60/node-10.2.1-darwin-x64.tar.gz"
       },
       {
         "filename": "node-10.2.1-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.2.1-20200430.53/node-10.2.1-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.2.1-20200504.60/node-10.2.1-linux-x64.tar.gz"
       },
       {
-        "filename": "node-10.2.1-win32-x64.zip",
+        "filename": "node-10.2.1-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.2.1-20200430.53/node-10.2.1-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.2.1-20200504.60/node-10.2.1-win32-x64.7z"
       }
     ]
   },
   {
     "version": "10.2.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/10.2.0-20200430.52",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/10.2.0-20200504.59",
     "files": [
       {
         "filename": "node-10.2.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.2.0-20200430.52/node-10.2.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.2.0-20200504.59/node-10.2.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-10.2.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.2.0-20200430.52/node-10.2.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.2.0-20200504.59/node-10.2.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-10.2.0-win32-x64.zip",
+        "filename": "node-10.2.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.2.0-20200430.52/node-10.2.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.2.0-20200504.59/node-10.2.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "10.1.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/10.1.0-20200430.32",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/10.1.0-20200504.39",
     "files": [
       {
         "filename": "node-10.1.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.1.0-20200430.32/node-10.1.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.1.0-20200504.39/node-10.1.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-10.1.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.1.0-20200430.32/node-10.1.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.1.0-20200504.39/node-10.1.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-10.1.0-win32-x64.zip",
+        "filename": "node-10.1.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.1.0-20200430.32/node-10.1.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.1.0-20200504.39/node-10.1.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "10.0.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/10.0.0-20200430.31",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/10.0.0-20200504.38",
     "files": [
       {
         "filename": "node-10.0.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.0.0-20200430.31/node-10.0.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.0.0-20200504.38/node-10.0.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-10.0.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.0.0-20200430.31/node-10.0.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.0.0-20200504.38/node-10.0.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-10.0.0-win32-x64.zip",
+        "filename": "node-10.0.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/10.0.0-20200430.31/node-10.0.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/10.0.0-20200504.38/node-10.0.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "8.17.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/8.17.0-20200423.26",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/8.17.0-20200504.23",
     "files": [
       {
         "filename": "node-8.17.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.17.0-20200423.26/node-8.17.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.17.0-20200504.23/node-8.17.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-8.17.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.17.0-20200423.26/node-8.17.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.17.0-20200504.23/node-8.17.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-8.17.0-win32-x64.zip",
+        "filename": "node-8.17.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.17.0-20200423.26/node-8.17.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.17.0-20200504.23/node-8.17.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "8.16.2",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/8.16.2-20200430.84",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/8.16.2-20200504.22",
     "files": [
       {
         "filename": "node-8.16.2-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.16.2-20200430.84/node-8.16.2-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.16.2-20200504.22/node-8.16.2-darwin-x64.tar.gz"
       },
       {
         "filename": "node-8.16.2-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.16.2-20200430.84/node-8.16.2-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.16.2-20200504.22/node-8.16.2-linux-x64.tar.gz"
       },
       {
-        "filename": "node-8.16.2-win32-x64.zip",
+        "filename": "node-8.16.2-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.16.2-20200430.84/node-8.16.2-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.16.2-20200504.22/node-8.16.2-win32-x64.7z"
       }
     ]
   },
   {
     "version": "8.16.1",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/8.16.1-20200430.83",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/8.16.1-20200504.21",
     "files": [
       {
         "filename": "node-8.16.1-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.16.1-20200430.83/node-8.16.1-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.16.1-20200504.21/node-8.16.1-darwin-x64.tar.gz"
       },
       {
         "filename": "node-8.16.1-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.16.1-20200430.83/node-8.16.1-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.16.1-20200504.21/node-8.16.1-linux-x64.tar.gz"
       },
       {
-        "filename": "node-8.16.1-win32-x64.zip",
+        "filename": "node-8.16.1-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.16.1-20200430.83/node-8.16.1-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.16.1-20200504.21/node-8.16.1-win32-x64.7z"
       }
     ]
   },
   {
     "version": "8.16.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/8.16.0-20200430.82",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/8.16.0-20200504.20",
     "files": [
       {
         "filename": "node-8.16.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.16.0-20200430.82/node-8.16.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.16.0-20200504.20/node-8.16.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-8.16.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.16.0-20200430.82/node-8.16.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.16.0-20200504.20/node-8.16.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-8.16.0-win32-x64.zip",
+        "filename": "node-8.16.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.16.0-20200430.82/node-8.16.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.16.0-20200504.20/node-8.16.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "8.15.1",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/8.15.1-20200430.81",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/8.15.1-20200504.19",
     "files": [
       {
         "filename": "node-8.15.1-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.15.1-20200430.81/node-8.15.1-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.15.1-20200504.19/node-8.15.1-darwin-x64.tar.gz"
       },
       {
         "filename": "node-8.15.1-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.15.1-20200430.81/node-8.15.1-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.15.1-20200504.19/node-8.15.1-linux-x64.tar.gz"
       },
       {
-        "filename": "node-8.15.1-win32-x64.zip",
+        "filename": "node-8.15.1-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.15.1-20200430.81/node-8.15.1-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.15.1-20200504.19/node-8.15.1-win32-x64.7z"
       }
     ]
   },
   {
     "version": "8.15.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/8.15.0-20200430.80",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/8.15.0-20200504.18",
     "files": [
       {
         "filename": "node-8.15.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.15.0-20200430.80/node-8.15.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.15.0-20200504.18/node-8.15.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-8.15.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.15.0-20200430.80/node-8.15.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.15.0-20200504.18/node-8.15.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-8.15.0-win32-x64.zip",
+        "filename": "node-8.15.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.15.0-20200430.80/node-8.15.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.15.0-20200504.18/node-8.15.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "8.14.1",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/8.14.1-20200430.79",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/8.14.1-20200504.17",
     "files": [
       {
         "filename": "node-8.14.1-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.14.1-20200430.79/node-8.14.1-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.14.1-20200504.17/node-8.14.1-darwin-x64.tar.gz"
       },
       {
         "filename": "node-8.14.1-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.14.1-20200430.79/node-8.14.1-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.14.1-20200504.17/node-8.14.1-linux-x64.tar.gz"
       },
       {
-        "filename": "node-8.14.1-win32-x64.zip",
+        "filename": "node-8.14.1-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.14.1-20200430.79/node-8.14.1-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.14.1-20200504.17/node-8.14.1-win32-x64.7z"
       }
     ]
   },
   {
     "version": "8.14.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/8.14.0-20200430.78",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/8.14.0-20200504.16",
     "files": [
       {
         "filename": "node-8.14.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.14.0-20200430.78/node-8.14.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.14.0-20200504.16/node-8.14.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-8.14.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.14.0-20200430.78/node-8.14.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.14.0-20200504.16/node-8.14.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-8.14.0-win32-x64.zip",
+        "filename": "node-8.14.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.14.0-20200430.78/node-8.14.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.14.0-20200504.16/node-8.14.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "8.13.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/8.13.0-20200430.77",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/8.13.0-20200504.15",
     "files": [
       {
         "filename": "node-8.13.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.13.0-20200430.77/node-8.13.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.13.0-20200504.15/node-8.13.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-8.13.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.13.0-20200430.77/node-8.13.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.13.0-20200504.15/node-8.13.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-8.13.0-win32-x64.zip",
+        "filename": "node-8.13.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.13.0-20200430.77/node-8.13.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.13.0-20200504.15/node-8.13.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "8.12.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/8.12.0-20200430.76",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/8.12.0-20200504.14",
     "files": [
       {
         "filename": "node-8.12.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.12.0-20200430.76/node-8.12.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.12.0-20200504.14/node-8.12.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-8.12.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.12.0-20200430.76/node-8.12.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.12.0-20200504.14/node-8.12.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-8.12.0-win32-x64.zip",
+        "filename": "node-8.12.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.12.0-20200430.76/node-8.12.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.12.0-20200504.14/node-8.12.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "8.11.4",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/8.11.4-20200430.75",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/8.11.4-20200504.13",
     "files": [
       {
         "filename": "node-8.11.4-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.11.4-20200430.75/node-8.11.4-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.11.4-20200504.13/node-8.11.4-darwin-x64.tar.gz"
       },
       {
         "filename": "node-8.11.4-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.11.4-20200430.75/node-8.11.4-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.11.4-20200504.13/node-8.11.4-linux-x64.tar.gz"
       },
       {
-        "filename": "node-8.11.4-win32-x64.zip",
+        "filename": "node-8.11.4-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.11.4-20200430.75/node-8.11.4-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.11.4-20200504.13/node-8.11.4-win32-x64.7z"
       }
     ]
   },
   {
     "version": "8.11.3",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/8.11.3-20200430.101",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/8.11.3-20200504.12",
     "files": [
       {
         "filename": "node-8.11.3-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.11.3-20200430.101/node-8.11.3-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.11.3-20200504.12/node-8.11.3-darwin-x64.tar.gz"
       },
       {
         "filename": "node-8.11.3-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.11.3-20200430.101/node-8.11.3-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.11.3-20200504.12/node-8.11.3-linux-x64.tar.gz"
       },
       {
-        "filename": "node-8.11.3-win32-x64.zip",
+        "filename": "node-8.11.3-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.11.3-20200430.101/node-8.11.3-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.11.3-20200504.12/node-8.11.3-win32-x64.7z"
       }
     ]
   },
   {
     "version": "8.11.2",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/8.11.2-20200430.73",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/8.11.2-20200504.11",
     "files": [
       {
         "filename": "node-8.11.2-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.11.2-20200430.73/node-8.11.2-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.11.2-20200504.11/node-8.11.2-darwin-x64.tar.gz"
       },
       {
         "filename": "node-8.11.2-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.11.2-20200430.73/node-8.11.2-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.11.2-20200504.11/node-8.11.2-linux-x64.tar.gz"
       },
       {
-        "filename": "node-8.11.2-win32-x64.zip",
+        "filename": "node-8.11.2-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.11.2-20200430.73/node-8.11.2-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.11.2-20200504.11/node-8.11.2-win32-x64.7z"
       }
     ]
   },
   {
     "version": "8.11.1",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/8.11.1-20200430.72",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/8.11.1-20200504.10",
     "files": [
       {
         "filename": "node-8.11.1-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.11.1-20200430.72/node-8.11.1-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.11.1-20200504.10/node-8.11.1-darwin-x64.tar.gz"
       },
       {
         "filename": "node-8.11.1-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.11.1-20200430.72/node-8.11.1-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.11.1-20200504.10/node-8.11.1-linux-x64.tar.gz"
       },
       {
-        "filename": "node-8.11.1-win32-x64.zip",
+        "filename": "node-8.11.1-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.11.1-20200430.72/node-8.11.1-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.11.1-20200504.10/node-8.11.1-win32-x64.7z"
       }
     ]
   },
   {
     "version": "8.11.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/8.11.0-20200430.71",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/8.11.0-20200504.9",
     "files": [
       {
         "filename": "node-8.11.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.11.0-20200430.71/node-8.11.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.11.0-20200504.9/node-8.11.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-8.11.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.11.0-20200430.71/node-8.11.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.11.0-20200504.9/node-8.11.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-8.11.0-win32-x64.zip",
+        "filename": "node-8.11.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.11.0-20200430.71/node-8.11.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.11.0-20200504.9/node-8.11.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "8.10.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/8.10.0-20200430.70",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/8.10.0-20200504.8",
     "files": [
       {
         "filename": "node-8.10.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.10.0-20200430.70/node-8.10.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.10.0-20200504.8/node-8.10.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-8.10.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.10.0-20200430.70/node-8.10.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.10.0-20200504.8/node-8.10.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-8.10.0-win32-x64.zip",
+        "filename": "node-8.10.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.10.0-20200430.70/node-8.10.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.10.0-20200504.8/node-8.10.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "8.9.4",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/8.9.4-20200430.99",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/8.9.4-20200504.37",
     "files": [
       {
         "filename": "node-8.9.4-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.9.4-20200430.99/node-8.9.4-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.9.4-20200504.37/node-8.9.4-darwin-x64.tar.gz"
       },
       {
         "filename": "node-8.9.4-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.9.4-20200430.99/node-8.9.4-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.9.4-20200504.37/node-8.9.4-linux-x64.tar.gz"
       },
       {
-        "filename": "node-8.9.4-win32-x64.zip",
+        "filename": "node-8.9.4-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.9.4-20200430.99/node-8.9.4-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.9.4-20200504.37/node-8.9.4-win32-x64.7z"
       }
     ]
   },
   {
     "version": "8.9.3",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/8.9.3-20200430.104",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/8.9.3-20200504.36",
     "files": [
       {
         "filename": "node-8.9.3-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.9.3-20200430.104/node-8.9.3-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.9.3-20200504.36/node-8.9.3-darwin-x64.tar.gz"
       },
       {
         "filename": "node-8.9.3-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.9.3-20200430.104/node-8.9.3-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.9.3-20200504.36/node-8.9.3-linux-x64.tar.gz"
       },
       {
-        "filename": "node-8.9.3-win32-x64.zip",
+        "filename": "node-8.9.3-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.9.3-20200430.104/node-8.9.3-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.9.3-20200504.36/node-8.9.3-win32-x64.7z"
       }
     ]
   },
   {
     "version": "8.9.2",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/8.9.2-20200430.97",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/8.9.2-20200504.35",
     "files": [
       {
         "filename": "node-8.9.2-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.9.2-20200430.97/node-8.9.2-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.9.2-20200504.35/node-8.9.2-darwin-x64.tar.gz"
       },
       {
         "filename": "node-8.9.2-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.9.2-20200430.97/node-8.9.2-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.9.2-20200504.35/node-8.9.2-linux-x64.tar.gz"
       },
       {
-        "filename": "node-8.9.2-win32-x64.zip",
+        "filename": "node-8.9.2-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.9.2-20200430.97/node-8.9.2-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.9.2-20200504.35/node-8.9.2-win32-x64.7z"
       }
     ]
   },
   {
     "version": "8.9.1",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/8.9.1-20200430.96",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/8.9.1-20200504.34",
     "files": [
       {
         "filename": "node-8.9.1-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.9.1-20200430.96/node-8.9.1-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.9.1-20200504.34/node-8.9.1-darwin-x64.tar.gz"
       },
       {
         "filename": "node-8.9.1-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.9.1-20200430.96/node-8.9.1-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.9.1-20200504.34/node-8.9.1-linux-x64.tar.gz"
       },
       {
-        "filename": "node-8.9.1-win32-x64.zip",
+        "filename": "node-8.9.1-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.9.1-20200430.96/node-8.9.1-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.9.1-20200504.34/node-8.9.1-win32-x64.7z"
       }
     ]
   },
   {
     "version": "8.9.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/8.9.0-20200430.95",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/8.9.0-20200504.33",
     "files": [
       {
         "filename": "node-8.9.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.9.0-20200430.95/node-8.9.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.9.0-20200504.33/node-8.9.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-8.9.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.9.0-20200430.95/node-8.9.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.9.0-20200504.33/node-8.9.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-8.9.0-win32-x64.zip",
+        "filename": "node-8.9.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.9.0-20200430.95/node-8.9.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.9.0-20200504.33/node-8.9.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "8.8.1",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/8.8.1-20200430.94",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/8.8.1-20200504.32",
     "files": [
       {
         "filename": "node-8.8.1-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.8.1-20200430.94/node-8.8.1-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.8.1-20200504.32/node-8.8.1-darwin-x64.tar.gz"
       },
       {
         "filename": "node-8.8.1-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.8.1-20200430.94/node-8.8.1-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.8.1-20200504.32/node-8.8.1-linux-x64.tar.gz"
       },
       {
-        "filename": "node-8.8.1-win32-x64.zip",
+        "filename": "node-8.8.1-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.8.1-20200430.94/node-8.8.1-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.8.1-20200504.32/node-8.8.1-win32-x64.7z"
       }
     ]
   },
   {
     "version": "8.8.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/8.8.0-20200430.93",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/8.8.0-20200504.31",
     "files": [
       {
         "filename": "node-8.8.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.8.0-20200430.93/node-8.8.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.8.0-20200504.31/node-8.8.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-8.8.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.8.0-20200430.93/node-8.8.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.8.0-20200504.31/node-8.8.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-8.8.0-win32-x64.zip",
+        "filename": "node-8.8.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.8.0-20200430.93/node-8.8.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.8.0-20200504.31/node-8.8.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "8.7.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/8.7.0-20200430.92",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/8.7.0-20200504.30",
     "files": [
       {
         "filename": "node-8.7.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.7.0-20200430.92/node-8.7.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.7.0-20200504.30/node-8.7.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-8.7.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.7.0-20200430.92/node-8.7.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.7.0-20200504.30/node-8.7.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-8.7.0-win32-x64.zip",
+        "filename": "node-8.7.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.7.0-20200430.92/node-8.7.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.7.0-20200504.30/node-8.7.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "8.6.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/8.6.0-20200430.103",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/8.6.0-20200504.29",
     "files": [
       {
         "filename": "node-8.6.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.6.0-20200430.103/node-8.6.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.6.0-20200504.29/node-8.6.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-8.6.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.6.0-20200430.103/node-8.6.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.6.0-20200504.29/node-8.6.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-8.6.0-win32-x64.zip",
+        "filename": "node-8.6.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.6.0-20200430.103/node-8.6.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.6.0-20200504.29/node-8.6.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "8.5.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/8.5.0-20200430.102",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/8.5.0-20200504.28",
     "files": [
       {
         "filename": "node-8.5.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.5.0-20200430.102/node-8.5.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.5.0-20200504.28/node-8.5.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-8.5.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.5.0-20200430.102/node-8.5.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.5.0-20200504.28/node-8.5.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-8.5.0-win32-x64.zip",
+        "filename": "node-8.5.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.5.0-20200430.102/node-8.5.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.5.0-20200504.28/node-8.5.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "8.4.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/8.4.0-20200430.89",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/8.4.0-20200504.27",
     "files": [
       {
         "filename": "node-8.4.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.4.0-20200430.89/node-8.4.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.4.0-20200504.27/node-8.4.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-8.4.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.4.0-20200430.89/node-8.4.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.4.0-20200504.27/node-8.4.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-8.4.0-win32-x64.zip",
+        "filename": "node-8.4.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.4.0-20200430.89/node-8.4.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.4.0-20200504.27/node-8.4.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "8.3.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/8.3.0-20200430.88",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/8.3.0-20200504.26",
     "files": [
       {
         "filename": "node-8.3.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.3.0-20200430.88/node-8.3.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.3.0-20200504.26/node-8.3.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-8.3.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.3.0-20200430.88/node-8.3.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.3.0-20200504.26/node-8.3.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-8.3.0-win32-x64.zip",
+        "filename": "node-8.3.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.3.0-20200430.88/node-8.3.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.3.0-20200504.26/node-8.3.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "8.2.1",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/8.2.1-20200430.87",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/8.2.1-20200504.25",
     "files": [
       {
         "filename": "node-8.2.1-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.2.1-20200430.87/node-8.2.1-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.2.1-20200504.25/node-8.2.1-darwin-x64.tar.gz"
       },
       {
         "filename": "node-8.2.1-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.2.1-20200430.87/node-8.2.1-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.2.1-20200504.25/node-8.2.1-linux-x64.tar.gz"
       },
       {
-        "filename": "node-8.2.1-win32-x64.zip",
+        "filename": "node-8.2.1-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.2.1-20200430.87/node-8.2.1-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.2.1-20200504.25/node-8.2.1-win32-x64.7z"
       }
     ]
   },
   {
     "version": "8.2.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/8.2.0-20200430.86",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/8.2.0-20200504.24",
     "files": [
       {
         "filename": "node-8.2.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.2.0-20200430.86/node-8.2.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.2.0-20200504.24/node-8.2.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-8.2.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.2.0-20200430.86/node-8.2.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.2.0-20200504.24/node-8.2.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-8.2.0-win32-x64.zip",
+        "filename": "node-8.2.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.2.0-20200430.86/node-8.2.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.2.0-20200504.24/node-8.2.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "8.1.4",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/8.1.4-20200430.69",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/8.1.4-20200504.7",
     "files": [
       {
         "filename": "node-8.1.4-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.1.4-20200430.69/node-8.1.4-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.1.4-20200504.7/node-8.1.4-darwin-x64.tar.gz"
       },
       {
         "filename": "node-8.1.4-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.1.4-20200430.69/node-8.1.4-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.1.4-20200504.7/node-8.1.4-linux-x64.tar.gz"
       },
       {
-        "filename": "node-8.1.4-win32-x64.zip",
+        "filename": "node-8.1.4-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.1.4-20200430.69/node-8.1.4-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.1.4-20200504.7/node-8.1.4-win32-x64.7z"
       }
     ]
   },
   {
     "version": "8.1.3",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/8.1.3-20200430.68",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/8.1.3-20200504.6",
     "files": [
       {
         "filename": "node-8.1.3-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.1.3-20200430.68/node-8.1.3-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.1.3-20200504.6/node-8.1.3-darwin-x64.tar.gz"
       },
       {
         "filename": "node-8.1.3-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.1.3-20200430.68/node-8.1.3-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.1.3-20200504.6/node-8.1.3-linux-x64.tar.gz"
       },
       {
-        "filename": "node-8.1.3-win32-x64.zip",
+        "filename": "node-8.1.3-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.1.3-20200430.68/node-8.1.3-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.1.3-20200504.6/node-8.1.3-win32-x64.7z"
       }
     ]
   },
   {
     "version": "8.1.2",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/8.1.2-20200430.67",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/8.1.2-20200504.5",
     "files": [
       {
         "filename": "node-8.1.2-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.1.2-20200430.67/node-8.1.2-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.1.2-20200504.5/node-8.1.2-darwin-x64.tar.gz"
       },
       {
         "filename": "node-8.1.2-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.1.2-20200430.67/node-8.1.2-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.1.2-20200504.5/node-8.1.2-linux-x64.tar.gz"
       },
       {
-        "filename": "node-8.1.2-win32-x64.zip",
+        "filename": "node-8.1.2-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.1.2-20200430.67/node-8.1.2-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.1.2-20200504.5/node-8.1.2-win32-x64.7z"
       }
     ]
   },
   {
     "version": "8.1.1",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/8.1.1-20200430.100",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/8.1.1-20200504.4",
     "files": [
       {
         "filename": "node-8.1.1-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.1.1-20200430.100/node-8.1.1-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.1.1-20200504.4/node-8.1.1-darwin-x64.tar.gz"
       },
       {
         "filename": "node-8.1.1-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.1.1-20200430.100/node-8.1.1-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.1.1-20200504.4/node-8.1.1-linux-x64.tar.gz"
       },
       {
-        "filename": "node-8.1.1-win32-x64.zip",
+        "filename": "node-8.1.1-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.1.1-20200430.100/node-8.1.1-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.1.1-20200504.4/node-8.1.1-win32-x64.7z"
       }
     ]
   },
   {
     "version": "8.1.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/8.1.0-20200430.65",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/8.1.0-20200504.3",
     "files": [
       {
         "filename": "node-8.1.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.1.0-20200430.65/node-8.1.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.1.0-20200504.3/node-8.1.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-8.1.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.1.0-20200430.65/node-8.1.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.1.0-20200504.3/node-8.1.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-8.1.0-win32-x64.zip",
+        "filename": "node-8.1.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.1.0-20200430.65/node-8.1.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.1.0-20200504.3/node-8.1.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "8.0.0",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/8.0.0-20200430.64",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/8.0.0-20200504.2",
     "files": [
       {
         "filename": "node-8.0.0-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.0.0-20200430.64/node-8.0.0-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.0.0-20200504.2/node-8.0.0-darwin-x64.tar.gz"
       },
       {
         "filename": "node-8.0.0-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.0.0-20200430.64/node-8.0.0-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.0.0-20200504.2/node-8.0.0-linux-x64.tar.gz"
       },
       {
-        "filename": "node-8.0.0-win32-x64.zip",
+        "filename": "node-8.0.0-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/8.0.0-20200430.64/node-8.0.0-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/8.0.0-20200504.2/node-8.0.0-win32-x64.7z"
       }
     ]
   },
   {
     "version": "6.17.1",
     "stable": true,
-    "release_url": "https://github.com/actions/node-versions/releases/tag/6.17.1-20200423.25",
+    "release_url": "https://github.com/actions/node-versions/releases/tag/6.17.1-20200504.99",
     "files": [
       {
         "filename": "node-6.17.1-darwin-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://github.com/actions/node-versions/releases/download/6.17.1-20200423.25/node-6.17.1-darwin-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/6.17.1-20200504.99/node-6.17.1-darwin-x64.tar.gz"
       },
       {
         "filename": "node-6.17.1-linux-x64.tar.gz",
         "arch": "x64",
         "platform": "linux",
-        "download_url": "https://github.com/actions/node-versions/releases/download/6.17.1-20200423.25/node-6.17.1-linux-x64.tar.gz"
+        "download_url": "https://github.com/actions/node-versions/releases/download/6.17.1-20200504.99/node-6.17.1-linux-x64.tar.gz"
       },
       {
-        "filename": "node-6.17.1-win32-x64.zip",
+        "filename": "node-6.17.1-win32-x64.7z",
         "arch": "x64",
         "platform": "win32",
-        "download_url": "https://github.com/actions/node-versions/releases/download/6.17.1-20200423.25/node-6.17.1-win32-x64.zip"
+        "download_url": "https://github.com/actions/node-versions/releases/download/6.17.1-20200504.99/node-6.17.1-win32-x64.7z"
       }
     ]
   }


### PR DESCRIPTION
Update versions-manifest.json for release from 05/04/2020

Re-upload all versions and switch windows packages from `*.zip` format to `*.7z` according #13 