### PR TITLE
Switch zip to 7z for windows

### DIFF
--- a/builders/win-node-builder.psm1
+++ b/builders/win-node-builder.psm1
@@ -27,7 +27,7 @@ class WinNodeBuilder : NodeBuilder {
     ) : Base($version, $platform, $architecture) {
         $this.InstallationTemplateName = "win-setup-template.ps1"
         $this.InstallationScriptName = "setup.ps1"
-        $this.OutputArtifactName = "node-$Version-$Platform-$Architecture.zip"
+        $this.OutputArtifactName = "node-$Version-$Platform-$Architecture.7z"
     }
 
     [uri] GetBinariesUri() {

--- a/builders/win-node-builder.psm1
+++ b/builders/win-node-builder.psm1
@@ -69,6 +69,6 @@ class WinNodeBuilder : NodeBuilder {
 
     [void] ArchiveArtifact() {
         $OutputPath = Join-Path $this.ArtifactFolderLocation $this.OutputArtifactName
-        Create-SevenZipArchive -SourceFolder $this.WorkFolderLocation -ArchivePath $OutputPath
+        Create-SevenZipArchive -SourceFolder $this.WorkFolderLocation -ArchivePath $OutputPath -ArchiveType "7z"
     }
 }


### PR DESCRIPTION
Use `7z` format for Windows packages because `zip` is not supported by [actions/toolkit](https://github.com/actions/toolkit/blob/master/packages/tool-cache/scripts/Invoke-7zdec.ps1)