### PR TITLE
Add ability to trigger packages generation on PRs

### DIFF
--- a/.github/workflows/build-node-packages.yml
+++ b/.github/workflows/build-node-packages.yml
@@ -10,19 +10,26 @@ on:
         description: 'Whether to publish releases'
         required: true
         default: 'false'
+  pull_request:
+    paths-ignore:
+    - 'versions-manifest.json'
+    - 'LICENSE'
+    - '**.md'
+    branches:
+    - 'main'
 
 env:
-  VERSION: ${{ github.event.inputs.VERSION }}
+  VERSION: ${{ github.event.inputs.VERSION || '14.0.0' }}
 defaults:
   run:
     shell: pwsh
 
 jobs:
   build_node:
-    name: Build Node.js ${{ github.event.inputs.VERSION }} [${{ matrix.platform }}]
+    name: Build Node.js ${{ github.event.inputs.VERSION || '14.0.0' }} [${{ matrix.platform }}]
     runs-on: ubuntu-latest
     env: 
-      ARTIFACT_NAME: node-${{ github.event.inputs.VERSION }}-${{ matrix.platform }}-x64
+      ARTIFACT_NAME: node-${{ github.event.inputs.VERSION || '14.0.0' }}-${{ matrix.platform }}-x64
     strategy:
       fail-fast: false
       matrix:
@@ -44,11 +51,11 @@ jobs:
         path: ${{ runner.temp }}/artifact
 
   test_node:
-    name: Test Node.js ${{ github.event.inputs.VERSION }} [${{ matrix.platform }}]
+    name: Test Node.js ${{ github.event.inputs.VERSION || '14.0.0' }} [${{ matrix.platform }}]
     needs: build_node
     runs-on: ${{ matrix.os }}
     env: 
-      ARTIFACT_NAME: node-${{ github.event.inputs.VERSION }}-${{ matrix.platform }}-x64
+      ARTIFACT_NAME: node-${{ github.event.inputs.VERSION || '14.0.0' }}-${{ matrix.platform }}-x64
     strategy:
       fail-fast: false
       matrix:
@@ -89,7 +96,7 @@ jobs:
       working-directory: ${{ runner.temp }}/${{ env.ARTIFACT_NAME }}
 
     - name: Setup Node.js ${{ env.VERSION }}
-      uses: actions/setup-node@v2.1.1
+      uses: actions/setup-node@v2.1.2
       with:
         node-version: ${{ env.VERSION }}
 
@@ -110,7 +117,7 @@ jobs:
 
   publish_release:
     name: Publish release
-    if: github.event.inputs.PUBLISH_RELEASES == 'true'
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.PUBLISH_RELEASES == 'true'
     needs: test_node
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
**Description**
We've added logic to run the `build-node-packages.yml` workflow when the `pull_request` event occurs. 

**Details:**
1) By default, a workflow only runs when a pull_request's activity type is `opened`, `synchronize`, or `reopened`. 
2) We've hardcoded the `14.0.0` version of Node.js for workflow runs on `pull_request` event.
3) New release will not be published if event is `pull_request`.
4) The workflow run associated with the `pull_request` event will be added as a PR check:

![image](https://user-images.githubusercontent.com/46996400/97871348-6c208c80-1d25-11eb-8e2d-51915318154d.png)

We have also updated version of the `setup-node` action from `v2.1.1` to `v2.1.2`.