### PR TITLE
Fix PowerShell issue with relative paths

### DIFF
--- a/builders/build-node.ps1
+++ b/builders/build-node.ps1
@@ -1,5 +1,5 @@
-using module "./builders/win-node-builder.psm1"
-using module "./builders/nix-node-builder.psm1"
+using module "./win-node-builder.psm1"
+using module "./nix-node-builder.psm1"
 
 <#
 .SYNOPSIS

--- a/builders/nix-node-builder.psm1
+++ b/builders/nix-node-builder.psm1
@@ -1,4 +1,4 @@
-using module "./builders/node-builder.psm1"
+using module "./node-builder.psm1"
 
 class NixNodeBuilder : NodeBuilder {
     <#

--- a/builders/win-node-builder.psm1
+++ b/builders/win-node-builder.psm1
@@ -1,4 +1,4 @@
-using module "./builders/node-builder.psm1"
+using module "./node-builder.psm1"
 
 class WinNodeBuilder : NodeBuilder {
     <#


### PR DESCRIPTION
PowerShell 7.1.0 introduces breaking changes that affect relative paths. Node packages generation fails with the following error:
```
The specified module '/home/runner/work/node-versions/node-versions/builders/builders/win-node-builder.psm1' was not loaded because no valid module file was found in any module directory.
```

In scope of this PR we prepared fix for this issue.

Related issue: [#1473](https://github.com/actions/virtual-environments-internal/issues/1473)