### PR TITLE
Add support for LTS labels in node-versions manifest

### DIFF
--- a/config/node-manifest-config.json
+++ b/config/node-manifest-config.json
@@ -3,5 +3,6 @@
     "groups": {
         "arch": 2,
         "platform": 1
-    }
+    },
+    "lts_rule_expression": "(Invoke-RestMethod 'https://raw.githubusercontent.com/nodejs/Release/main/schedule.json').PSObject.Properties | Where-Object { $_.Value.codename } | ForEach-Object { @{ Name = $_.Name.TrimStart('v'); Value = $_.Value.codename } }"
 }

--- a/versions-manifest.json
+++ b/versions-manifest.json
@@ -102,6 +102,7 @@
   {
     "version": "14.17.1",
     "stable": true,
+    "lts": "Fermium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/14.17.1-939440767",
     "files": [
       {
@@ -127,6 +128,7 @@
   {
     "version": "14.17.0",
     "stable": true,
+    "lts": "Fermium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/14.17.0-834391622",
     "files": [
       {
@@ -152,6 +154,7 @@
   {
     "version": "14.16.1",
     "stable": true,
+    "lts": "Fermium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/14.16.1-725059535",
     "files": [
       {
@@ -177,6 +180,7 @@
   {
     "version": "14.16.0",
     "stable": true,
+    "lts": "Fermium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/14.16.0-592967501",
     "files": [
       {
@@ -202,6 +206,7 @@
   {
     "version": "14.15.5",
     "stable": true,
+    "lts": "Fermium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/14.15.5-553881828",
     "files": [
       {
@@ -227,6 +232,7 @@
   {
     "version": "14.15.4",
     "stable": true,
+    "lts": "Fermium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/14.15.4-465482797",
     "files": [
       {
@@ -252,6 +258,7 @@
   {
     "version": "14.15.3",
     "stable": true,
+    "lts": "Fermium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/14.15.3-429909779",
     "files": [
       {
@@ -277,6 +284,7 @@
   {
     "version": "14.15.2",
     "stable": true,
+    "lts": "Fermium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/14.15.2-425529371",
     "files": [
       {
@@ -302,6 +310,7 @@
   {
     "version": "14.15.1",
     "stable": true,
+    "lts": "Fermium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/14.15.1-368657841",
     "files": [
       {
@@ -327,6 +336,7 @@
   {
     "version": "14.15.0",
     "stable": true,
+    "lts": "Fermium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/14.15.0-333017252",
     "files": [
       {
@@ -352,6 +362,7 @@
   {
     "version": "14.14.0",
     "stable": true,
+    "lts": "Fermium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/14.14.0-310900524",
     "files": [
       {
@@ -377,6 +388,7 @@
   {
     "version": "14.13.1",
     "stable": true,
+    "lts": "Fermium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/14.13.1-294907768",
     "files": [
       {
@@ -402,6 +414,7 @@
   {
     "version": "14.13.0",
     "stable": true,
+    "lts": "Fermium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/14.13.0-279958998",
     "files": [
       {
@@ -427,6 +440,7 @@
   {
     "version": "14.12.0",
     "stable": true,
+    "lts": "Fermium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/14.12.0-268499334",
     "files": [
       {
@@ -452,6 +466,7 @@
   {
     "version": "14.11.0",
     "stable": true,
+    "lts": "Fermium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/14.11.0-257117476",
     "files": [
       {
@@ -477,6 +492,7 @@
   {
     "version": "14.10.1",
     "stable": true,
+    "lts": "Fermium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/14.10.1-248429513",
     "files": [
       {
@@ -502,6 +518,7 @@
   {
     "version": "14.10.0",
     "stable": true,
+    "lts": "Fermium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/14.10.0-245899283",
     "files": [
       {
@@ -527,6 +544,7 @@
   {
     "version": "14.9.0",
     "stable": true,
+    "lts": "Fermium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/14.9.0-227321496",
     "files": [
       {
@@ -552,6 +570,7 @@
   {
     "version": "14.8.0",
     "stable": true,
+    "lts": "Fermium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/14.8.0-20200812.4",
     "files": [
       {
@@ -577,6 +596,7 @@
   {
     "version": "14.7.0",
     "stable": true,
+    "lts": "Fermium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/14.7.0-20200730.1",
     "files": [
       {
@@ -602,6 +622,7 @@
   {
     "version": "14.6.0",
     "stable": true,
+    "lts": "Fermium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/14.6.0-20200722.1",
     "files": [
       {
@@ -627,6 +648,7 @@
   {
     "version": "14.5.0",
     "stable": true,
+    "lts": "Fermium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/14.5.0-20200707.1",
     "files": [
       {
@@ -652,6 +674,7 @@
   {
     "version": "14.4.0",
     "stable": true,
+    "lts": "Fermium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/14.4.0-20200603.1",
     "files": [
       {
@@ -677,6 +700,7 @@
   {
     "version": "14.3.0",
     "stable": true,
+    "lts": "Fermium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/14.3.0-20200521.1",
     "files": [
       {
@@ -702,6 +726,7 @@
   {
     "version": "14.2.0",
     "stable": true,
+    "lts": "Fermium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/14.2.0-20200507.101",
     "files": [
       {
@@ -727,6 +752,7 @@
   {
     "version": "14.1.0",
     "stable": true,
+    "lts": "Fermium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/14.1.0-20200507.100",
     "files": [
       {
@@ -752,6 +778,7 @@
   {
     "version": "14.0.0",
     "stable": true,
+    "lts": "Fermium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/14.0.0-20200507.99",
     "files": [
       {
@@ -827,6 +854,7 @@
   {
     "version": "12.22.1",
     "stable": true,
+    "lts": "Erbium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/12.22.1-725060020",
     "files": [
       {
@@ -852,6 +880,7 @@
   {
     "version": "12.22.0",
     "stable": true,
+    "lts": "Erbium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/12.22.0-701877149",
     "files": [
       {
@@ -877,6 +906,7 @@
   {
     "version": "12.21.0",
     "stable": true,
+    "lts": "Erbium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/12.21.0-592968123",
     "files": [
       {
@@ -902,6 +932,7 @@
   {
     "version": "12.20.2",
     "stable": true,
+    "lts": "Erbium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/12.20.2-557008033",
     "files": [
       {
@@ -927,6 +958,7 @@
   {
     "version": "12.20.1",
     "stable": true,
+    "lts": "Erbium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/12.20.1-465483151",
     "files": [
       {
@@ -952,6 +984,7 @@
   {
     "version": "12.20.0",
     "stable": true,
+    "lts": "Erbium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/12.20.0-382715243",
     "files": [
       {
@@ -977,6 +1010,7 @@
   {
     "version": "12.19.1",
     "stable": true,
+    "lts": "Erbium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/12.19.1-368658215",
     "files": [
       {
@@ -1002,6 +1036,7 @@
   {
     "version": "12.19.0",
     "stable": true,
+    "lts": "Erbium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/12.19.0-292997882",
     "files": [
       {
@@ -1027,6 +1062,7 @@
   {
     "version": "12.18.4",
     "stable": true,
+    "lts": "Erbium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/12.18.4-257117621",
     "files": [
       {
@@ -1052,6 +1088,7 @@
   {
     "version": "12.18.3",
     "stable": true,
+    "lts": "Erbium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/12.18.3-20200723.1",
     "files": [
       {
@@ -1077,6 +1114,7 @@
   {
     "version": "12.18.2",
     "stable": true,
+    "lts": "Erbium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/12.18.2-20200707.2",
     "files": [
       {
@@ -1102,6 +1140,7 @@
   {
     "version": "12.18.1",
     "stable": true,
+    "lts": "Erbium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/12.18.1-20200617.1",
     "files": [
       {
@@ -1127,6 +1166,7 @@
   {
     "version": "12.18.0",
     "stable": true,
+    "lts": "Erbium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/12.18.0-20200603.2",
     "files": [
       {
@@ -1152,6 +1192,7 @@
   {
     "version": "12.17.0",
     "stable": true,
+    "lts": "Erbium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/12.17.0-20200526.1",
     "files": [
       {
@@ -1177,6 +1218,7 @@
   {
     "version": "12.16.3",
     "stable": true,
+    "lts": "Erbium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/12.16.3-20200507.96",
     "files": [
       {
@@ -1202,6 +1244,7 @@
   {
     "version": "12.16.2",
     "stable": true,
+    "lts": "Erbium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/12.16.2-20200507.95",
     "files": [
       {
@@ -1227,6 +1270,7 @@
   {
     "version": "12.16.1",
     "stable": true,
+    "lts": "Erbium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/12.16.1-20200507.94",
     "files": [
       {
@@ -1252,6 +1296,7 @@
   {
     "version": "12.16.0",
     "stable": true,
+    "lts": "Erbium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/12.16.0-20200507.93",
     "files": [
       {
@@ -1277,6 +1322,7 @@
   {
     "version": "12.15.0",
     "stable": true,
+    "lts": "Erbium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/12.15.0-20200507.92",
     "files": [
       {
@@ -1302,6 +1348,7 @@
   {
     "version": "12.14.1",
     "stable": true,
+    "lts": "Erbium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/12.14.1-20200507.91",
     "files": [
       {
@@ -1327,6 +1374,7 @@
   {
     "version": "12.14.0",
     "stable": true,
+    "lts": "Erbium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/12.14.0-20200507.90",
     "files": [
       {
@@ -1352,6 +1400,7 @@
   {
     "version": "12.13.1",
     "stable": true,
+    "lts": "Erbium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/12.13.1-20200507.89",
     "files": [
       {
@@ -1377,6 +1426,7 @@
   {
     "version": "12.13.0",
     "stable": true,
+    "lts": "Erbium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/12.13.0-20200507.88",
     "files": [
       {
@@ -1402,6 +1452,7 @@
   {
     "version": "12.12.0",
     "stable": true,
+    "lts": "Erbium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/12.12.0-20200507.87",
     "files": [
       {
@@ -1427,6 +1478,7 @@
   {
     "version": "12.11.1",
     "stable": true,
+    "lts": "Erbium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/12.11.1-20200507.86",
     "files": [
       {
@@ -1452,6 +1504,7 @@
   {
     "version": "12.11.0",
     "stable": true,
+    "lts": "Erbium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/12.11.0-20200507.85",
     "files": [
       {
@@ -1477,6 +1530,7 @@
   {
     "version": "12.10.0",
     "stable": true,
+    "lts": "Erbium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/12.10.0-20200507.84",
     "files": [
       {
@@ -1502,6 +1556,7 @@
   {
     "version": "12.9.1",
     "stable": true,
+    "lts": "Erbium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/12.9.1-20200507.83",
     "files": [
       {
@@ -1527,6 +1582,7 @@
   {
     "version": "12.9.0",
     "stable": true,
+    "lts": "Erbium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/12.9.0-20200507.82",
     "files": [
       {
@@ -1552,6 +1608,7 @@
   {
     "version": "12.8.1",
     "stable": true,
+    "lts": "Erbium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/12.8.1-20200507.81",
     "files": [
       {
@@ -1577,6 +1634,7 @@
   {
     "version": "12.8.0",
     "stable": true,
+    "lts": "Erbium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/12.8.0-20200507.80",
     "files": [
       {
@@ -1602,6 +1660,7 @@
   {
     "version": "12.7.0",
     "stable": true,
+    "lts": "Erbium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/12.7.0-20200507.79",
     "files": [
       {
@@ -1627,6 +1686,7 @@
   {
     "version": "12.6.0",
     "stable": true,
+    "lts": "Erbium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/12.6.0-20200507.78",
     "files": [
       {
@@ -1652,6 +1712,7 @@
   {
     "version": "12.5.0",
     "stable": true,
+    "lts": "Erbium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/12.5.0-20200507.77",
     "files": [
       {
@@ -1677,6 +1738,7 @@
   {
     "version": "12.4.0",
     "stable": true,
+    "lts": "Erbium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/12.4.0-20200507.76",
     "files": [
       {
@@ -1702,6 +1764,7 @@
   {
     "version": "12.3.1",
     "stable": true,
+    "lts": "Erbium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/12.3.1-20200507.75",
     "files": [
       {
@@ -1727,6 +1790,7 @@
   {
     "version": "12.3.0",
     "stable": true,
+    "lts": "Erbium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/12.3.0-20200507.74",
     "files": [
       {
@@ -1752,6 +1816,7 @@
   {
     "version": "12.2.0",
     "stable": true,
+    "lts": "Erbium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/12.2.0-20200507.73",
     "files": [
       {
@@ -1777,6 +1842,7 @@
   {
     "version": "12.1.0",
     "stable": true,
+    "lts": "Erbium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/12.1.0-20200507.72",
     "files": [
       {
@@ -1802,6 +1868,7 @@
   {
     "version": "12.0.0",
     "stable": true,
+    "lts": "Erbium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/12.0.0-20200507.71",
     "files": [
       {
@@ -1827,6 +1894,7 @@
   {
     "version": "10.24.1",
     "stable": true,
+    "lts": "Dubnium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/10.24.1-725060485",
     "files": [
       {
@@ -1852,6 +1920,7 @@
   {
     "version": "10.24.0",
     "stable": true,
+    "lts": "Dubnium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/10.24.0-592968584",
     "files": [
       {
@@ -1877,6 +1946,7 @@
   {
     "version": "10.23.3",
     "stable": true,
+    "lts": "Dubnium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/10.23.3-553882324",
     "files": [
       {
@@ -1902,6 +1972,7 @@
   {
     "version": "10.23.2",
     "stable": true,
+    "lts": "Dubnium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/10.23.2-514267332",
     "files": [
       {
@@ -1927,6 +1998,7 @@
   {
     "version": "10.23.1",
     "stable": true,
+    "lts": "Dubnium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/10.23.1-465483438",
     "files": [
       {
@@ -1952,6 +2024,7 @@
   {
     "version": "10.23.0",
     "stable": true,
+    "lts": "Dubnium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/10.23.0-333017621",
     "files": [
       {
@@ -1977,6 +2050,7 @@
   {
     "version": "10.22.1",
     "stable": true,
+    "lts": "Dubnium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/10.22.1-257117732",
     "files": [
       {
@@ -2002,6 +2076,7 @@
   {
     "version": "10.22.0",
     "stable": true,
+    "lts": "Dubnium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/10.22.0-20200722.2",
     "files": [
       {
@@ -2027,6 +2102,7 @@
   {
     "version": "10.21.0",
     "stable": true,
+    "lts": "Dubnium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/10.21.0-20200603.3",
     "files": [
       {
@@ -2052,6 +2128,7 @@
   {
     "version": "10.20.1",
     "stable": true,
+    "lts": "Dubnium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/10.20.1-20200507.70",
     "files": [
       {
@@ -2077,6 +2154,7 @@
   {
     "version": "10.20.0",
     "stable": true,
+    "lts": "Dubnium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/10.20.0-20200507.69",
     "files": [
       {
@@ -2102,6 +2180,7 @@
   {
     "version": "10.19.0",
     "stable": true,
+    "lts": "Dubnium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/10.19.0-20200507.68",
     "files": [
       {
@@ -2127,6 +2206,7 @@
   {
     "version": "10.18.1",
     "stable": true,
+    "lts": "Dubnium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/10.18.1-20200507.67",
     "files": [
       {
@@ -2152,6 +2232,7 @@
   {
     "version": "10.18.0",
     "stable": true,
+    "lts": "Dubnium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/10.18.0-20200507.66",
     "files": [
       {
@@ -2177,6 +2258,7 @@
   {
     "version": "10.17.0",
     "stable": true,
+    "lts": "Dubnium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/10.17.0-20200507.65",
     "files": [
       {
@@ -2202,6 +2284,7 @@
   {
     "version": "10.16.3",
     "stable": true,
+    "lts": "Dubnium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/10.16.3-20200507.64",
     "files": [
       {
@@ -2227,6 +2310,7 @@
   {
     "version": "10.16.2",
     "stable": true,
+    "lts": "Dubnium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/10.16.2-20200507.63",
     "files": [
       {
@@ -2252,6 +2336,7 @@
   {
     "version": "10.16.1",
     "stable": true,
+    "lts": "Dubnium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/10.16.1-20200507.62",
     "files": [
       {
@@ -2277,6 +2362,7 @@
   {
     "version": "10.16.0",
     "stable": true,
+    "lts": "Dubnium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/10.16.0-20200507.61",
     "files": [
       {
@@ -2302,6 +2388,7 @@
   {
     "version": "10.15.3",
     "stable": true,
+    "lts": "Dubnium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/10.15.3-20200507.60",
     "files": [
       {
@@ -2327,6 +2414,7 @@
   {
     "version": "10.15.2",
     "stable": true,
+    "lts": "Dubnium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/10.15.2-20200507.59",
     "files": [
       {
@@ -2352,6 +2440,7 @@
   {
     "version": "10.15.1",
     "stable": true,
+    "lts": "Dubnium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/10.15.1-20200507.58",
     "files": [
       {
@@ -2377,6 +2466,7 @@
   {
     "version": "10.15.0",
     "stable": true,
+    "lts": "Dubnium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/10.15.0-20200507.57",
     "files": [
       {
@@ -2402,6 +2492,7 @@
   {
     "version": "10.14.2",
     "stable": true,
+    "lts": "Dubnium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/10.14.2-20200507.56",
     "files": [
       {
@@ -2427,6 +2518,7 @@
   {
     "version": "10.14.1",
     "stable": true,
+    "lts": "Dubnium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/10.14.1-20200507.55",
     "files": [
       {
@@ -2452,6 +2544,7 @@
   {
     "version": "10.14.0",
     "stable": true,
+    "lts": "Dubnium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/10.14.0-20200507.54",
     "files": [
       {
@@ -2477,6 +2570,7 @@
   {
     "version": "10.13.0",
     "stable": true,
+    "lts": "Dubnium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/10.13.0-20200507.53",
     "files": [
       {
@@ -2502,6 +2596,7 @@
   {
     "version": "10.12.0",
     "stable": true,
+    "lts": "Dubnium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/10.12.0-20200507.52",
     "files": [
       {
@@ -2527,6 +2622,7 @@
   {
     "version": "10.11.0",
     "stable": true,
+    "lts": "Dubnium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/10.11.0-20200507.51",
     "files": [
       {
@@ -2552,6 +2648,7 @@
   {
     "version": "10.10.0",
     "stable": true,
+    "lts": "Dubnium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/10.10.0-20200507.50",
     "files": [
       {
@@ -2577,6 +2674,7 @@
   {
     "version": "10.9.0",
     "stable": true,
+    "lts": "Dubnium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/10.9.0-20200507.49",
     "files": [
       {
@@ -2602,6 +2700,7 @@
   {
     "version": "10.8.0",
     "stable": true,
+    "lts": "Dubnium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/10.8.0-20200507.48",
     "files": [
       {
@@ -2627,6 +2726,7 @@
   {
     "version": "10.7.0",
     "stable": true,
+    "lts": "Dubnium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/10.7.0-20200507.47",
     "files": [
       {
@@ -2652,6 +2752,7 @@
   {
     "version": "10.6.0",
     "stable": true,
+    "lts": "Dubnium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/10.6.0-20200507.46",
     "files": [
       {
@@ -2677,6 +2778,7 @@
   {
     "version": "10.5.0",
     "stable": true,
+    "lts": "Dubnium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/10.5.0-20200507.45",
     "files": [
       {
@@ -2702,6 +2804,7 @@
   {
     "version": "10.4.1",
     "stable": true,
+    "lts": "Dubnium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/10.4.1-20200507.44",
     "files": [
       {
@@ -2727,6 +2830,7 @@
   {
     "version": "10.4.0",
     "stable": true,
+    "lts": "Dubnium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/10.4.0-20200507.43",
     "files": [
       {
@@ -2752,6 +2856,7 @@
   {
     "version": "10.3.0",
     "stable": true,
+    "lts": "Dubnium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/10.3.0-20200507.42",
     "files": [
       {
@@ -2777,6 +2882,7 @@
   {
     "version": "10.2.1",
     "stable": true,
+    "lts": "Dubnium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/10.2.1-20200507.41",
     "files": [
       {
@@ -2802,6 +2908,7 @@
   {
     "version": "10.2.0",
     "stable": true,
+    "lts": "Dubnium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/10.2.0-20200507.40",
     "files": [
       {
@@ -2827,6 +2934,7 @@
   {
     "version": "10.1.0",
     "stable": true,
+    "lts": "Dubnium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/10.1.0-20200507.39",
     "files": [
       {
@@ -2852,6 +2960,7 @@
   {
     "version": "10.0.0",
     "stable": true,
+    "lts": "Dubnium",
     "release_url": "https://github.com/actions/node-versions/releases/tag/10.0.0-20200507.38",
     "files": [
       {
@@ -2877,6 +2986,7 @@
   {
     "version": "8.17.0",
     "stable": true,
+    "lts": "Carbon",
     "release_url": "https://github.com/actions/node-versions/releases/tag/8.17.0-20200507.37",
     "files": [
       {
@@ -2902,6 +3012,7 @@
   {
     "version": "8.16.2",
     "stable": true,
+    "lts": "Carbon",
     "release_url": "https://github.com/actions/node-versions/releases/tag/8.16.2-20200507.36",
     "files": [
       {
@@ -2927,6 +3038,7 @@
   {
     "version": "8.16.1",
     "stable": true,
+    "lts": "Carbon",
     "release_url": "https://github.com/actions/node-versions/releases/tag/8.16.1-20200507.35",
     "files": [
       {
@@ -2952,6 +3064,7 @@
   {
     "version": "8.16.0",
     "stable": true,
+    "lts": "Carbon",
     "release_url": "https://github.com/actions/node-versions/releases/tag/8.16.0-20200507.34",
     "files": [
       {
@@ -2977,6 +3090,7 @@
   {
     "version": "8.15.1",
     "stable": true,
+    "lts": "Carbon",
     "release_url": "https://github.com/actions/node-versions/releases/tag/8.15.1-20200507.33",
     "files": [
       {
@@ -3002,6 +3116,7 @@
   {
     "version": "8.15.0",
     "stable": true,
+    "lts": "Carbon",
     "release_url": "https://github.com/actions/node-versions/releases/tag/8.15.0-20200507.32",
     "files": [
       {
@@ -3027,6 +3142,7 @@
   {
     "version": "8.14.1",
     "stable": true,
+    "lts": "Carbon",
     "release_url": "https://github.com/actions/node-versions/releases/tag/8.14.1-20200507.31",
     "files": [
       {
@@ -3052,6 +3168,7 @@
   {
     "version": "8.14.0",
     "stable": true,
+    "lts": "Carbon",
     "release_url": "https://github.com/actions/node-versions/releases/tag/8.14.0-20200507.30",
     "files": [
       {
@@ -3077,6 +3194,7 @@
   {
     "version": "8.13.0",
     "stable": true,
+    "lts": "Carbon",
     "release_url": "https://github.com/actions/node-versions/releases/tag/8.13.0-20200507.29",
     "files": [
       {
@@ -3102,6 +3220,7 @@
   {
     "version": "8.12.0",
     "stable": true,
+    "lts": "Carbon",
     "release_url": "https://github.com/actions/node-versions/releases/tag/8.12.0-20200507.28",
     "files": [
       {
@@ -3127,6 +3246,7 @@
   {
     "version": "8.11.4",
     "stable": true,
+    "lts": "Carbon",
     "release_url": "https://github.com/actions/node-versions/releases/tag/8.11.4-20200507.27",
     "files": [
       {
@@ -3152,6 +3272,7 @@
   {
     "version": "8.11.3",
     "stable": true,
+    "lts": "Carbon",
     "release_url": "https://github.com/actions/node-versions/releases/tag/8.11.3-20200507.26",
     "files": [
       {
@@ -3177,6 +3298,7 @@
   {
     "version": "8.11.2",
     "stable": true,
+    "lts": "Carbon",
     "release_url": "https://github.com/actions/node-versions/releases/tag/8.11.2-20200507.25",
     "files": [
       {
@@ -3202,6 +3324,7 @@
   {
     "version": "8.11.1",
     "stable": true,
+    "lts": "Carbon",
     "release_url": "https://github.com/actions/node-versions/releases/tag/8.11.1-20200507.24",
     "files": [
       {
@@ -3227,6 +3350,7 @@
   {
     "version": "8.11.0",
     "stable": true,
+    "lts": "Carbon",
     "release_url": "https://github.com/actions/node-versions/releases/tag/8.11.0-20200507.23",
     "files": [
       {
@@ -3252,6 +3376,7 @@
   {
     "version": "8.10.0",
     "stable": true,
+    "lts": "Carbon",
     "release_url": "https://github.com/actions/node-versions/releases/tag/8.10.0-20200507.22",
     "files": [
       {
@@ -3277,6 +3402,7 @@
   {
     "version": "8.9.4",
     "stable": true,
+    "lts": "Carbon",
     "release_url": "https://github.com/actions/node-versions/releases/tag/8.9.4-20200507.21",
     "files": [
       {
@@ -3302,6 +3428,7 @@
   {
     "version": "8.9.3",
     "stable": true,
+    "lts": "Carbon",
     "release_url": "https://github.com/actions/node-versions/releases/tag/8.9.3-20200507.20",
     "files": [
       {
@@ -3327,6 +3454,7 @@
   {
     "version": "8.9.2",
     "stable": true,
+    "lts": "Carbon",
     "release_url": "https://github.com/actions/node-versions/releases/tag/8.9.2-20200507.19",
     "files": [
       {
@@ -3352,6 +3480,7 @@
   {
     "version": "8.9.1",
     "stable": true,
+    "lts": "Carbon",
     "release_url": "https://github.com/actions/node-versions/releases/tag/8.9.1-20200507.18",
     "files": [
       {
@@ -3377,6 +3506,7 @@
   {
     "version": "8.9.0",
     "stable": true,
+    "lts": "Carbon",
     "release_url": "https://github.com/actions/node-versions/releases/tag/8.9.0-20200507.17",
     "files": [
       {
@@ -3402,6 +3532,7 @@
   {
     "version": "8.8.1",
     "stable": true,
+    "lts": "Carbon",
     "release_url": "https://github.com/actions/node-versions/releases/tag/8.8.1-20200507.16",
     "files": [
       {
@@ -3427,6 +3558,7 @@
   {
     "version": "8.8.0",
     "stable": true,
+    "lts": "Carbon",
     "release_url": "https://github.com/actions/node-versions/releases/tag/8.8.0-20200507.15",
     "files": [
       {
@@ -3452,6 +3584,7 @@
   {
     "version": "8.7.0",
     "stable": true,
+    "lts": "Carbon",
     "release_url": "https://github.com/actions/node-versions/releases/tag/8.7.0-20200507.14",
     "files": [
       {
@@ -3477,6 +3610,7 @@
   {
     "version": "8.6.0",
     "stable": true,
+    "lts": "Carbon",
     "release_url": "https://github.com/actions/node-versions/releases/tag/8.6.0-20200529.14",
     "files": [
       {
@@ -3502,6 +3636,7 @@
   {
     "version": "8.5.0",
     "stable": true,
+    "lts": "Carbon",
     "release_url": "https://github.com/actions/node-versions/releases/tag/8.5.0-20200507.12",
     "files": [
       {
@@ -3527,6 +3662,7 @@
   {
     "version": "8.4.0",
     "stable": true,
+    "lts": "Carbon",
     "release_url": "https://github.com/actions/node-versions/releases/tag/8.4.0-20200507.11",
     "files": [
       {
@@ -3552,6 +3688,7 @@
   {
     "version": "8.3.0",
     "stable": true,
+    "lts": "Carbon",
     "release_url": "https://github.com/actions/node-versions/releases/tag/8.3.0-20200507.10",
     "files": [
       {
@@ -3577,6 +3714,7 @@
   {
     "version": "8.2.1",
     "stable": true,
+    "lts": "Carbon",
     "release_url": "https://github.com/actions/node-versions/releases/tag/8.2.1-20200507.9",
     "files": [
       {
@@ -3602,6 +3740,7 @@
   {
     "version": "8.2.0",
     "stable": true,
+    "lts": "Carbon",
     "release_url": "https://github.com/actions/node-versions/releases/tag/8.2.0-20200507.8",
     "files": [
       {
@@ -3627,6 +3766,7 @@
   {
     "version": "8.1.4",
     "stable": true,
+    "lts": "Carbon",
     "release_url": "https://github.com/actions/node-versions/releases/tag/8.1.4-20200507.7",
     "files": [
       {
@@ -3652,6 +3792,7 @@
   {
     "version": "8.1.3",
     "stable": true,
+    "lts": "Carbon",
     "release_url": "https://github.com/actions/node-versions/releases/tag/8.1.3-20200507.6",
     "files": [
       {
@@ -3677,6 +3818,7 @@
   {
     "version": "8.1.2",
     "stable": true,
+    "lts": "Carbon",
     "release_url": "https://github.com/actions/node-versions/releases/tag/8.1.2-20200529.6",
     "files": [
       {
@@ -3702,6 +3844,7 @@
   {
     "version": "8.1.1",
     "stable": true,
+    "lts": "Carbon",
     "release_url": "https://github.com/actions/node-versions/releases/tag/8.1.1-20200507.4",
     "files": [
       {
@@ -3727,6 +3870,7 @@
   {
     "version": "8.1.0",
     "stable": true,
+    "lts": "Carbon",
     "release_url": "https://github.com/actions/node-versions/releases/tag/8.1.0-20200507.3",
     "files": [
       {
@@ -3752,6 +3896,7 @@
   {
     "version": "8.0.0",
     "stable": true,
+    "lts": "Carbon",
     "release_url": "https://github.com/actions/node-versions/releases/tag/8.0.0-20200507.2",
     "files": [
       {
@@ -3777,6 +3922,7 @@
   {
     "version": "6.17.1",
     "stable": true,
+    "lts": "Boron",
     "release_url": "https://github.com/actions/node-versions/releases/tag/6.17.1-20200529.2",
     "files": [
       {


### PR DESCRIPTION
Add information about LTS status for versions in manifest. Based on https://github.com/actions/versions-package-tools/pull/32