### PR TITLE
Move get-node-versions pipeline from Azure DevOps

### DIFF
--- a/.github/workflows/get-node-versions.yml
+++ b/.github/workflows/get-node-versions.yml
@@ -1,0 +1,97 @@
+name: Get Node versions
+on:
+  schedule:
+    - cron: '0 3,15 * * *'
+  workflow_dispatch:
+
+env:
+  TOOL_NAME: "Node"
+defaults:
+  run:
+    shell: pwsh
+
+jobs:
+  find_new_versions:
+    name: Find new versions
+    runs-on: ubuntu-latest
+    outputs:
+      versions_output: ${{ steps.Get_new_versions.outputs.TOOL_VERSIONS }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - id: Get_new_versions
+        name: Get new versions
+        run: ./helpers/get-new-tool-versions/get-new-tool-versions.ps1 -ToolName ${{ env.TOOL_NAME }}
+
+  check_new_versions:
+    name: Check new versions
+    runs-on: ubuntu-latest
+    needs: find_new_versions
+    env:
+      TOOL_VERSIONS: ${{needs.find_new_versions.outputs.versions_output}}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Check Versions
+        if: success() && env.TOOL_VERSIONS == ''
+        run: |
+          Write-Host "No new versions were found"
+          Import-Module "./helpers/github/github-api.psm1"
+          $gitHubApi = Get-GitHubApi -RepositoryFullName "$env:GITHUB_REPOSITORY" `
+                                     -AccessToken "${{ secrets.PERSONAL_TOKEN }}"
+
+          $gitHubApi.CancelWorkflow("$env:GITHUB_RUN_ID")
+          Start-Sleep -Seconds 60
+
+      - name: Send Slack notification
+        run: |
+          $pipelineUrl = "$env:GITHUB_SERVER_URL/$env:GITHUB_REPOSITORY/actions/runs/$env:GITHUB_RUN_ID"
+          ./helpers/get-new-tool-versions/send-slack-notification.ps1 -Url "${{ secrets.SLACK_CHANNEL_URL }}" `
+                                                                      -ToolName "${{ env.TOOL_NAME }}" `
+                                                                      -ToolVersion "${{ env.TOOL_VERSIONS }}" `
+                                                                      -PipelineUrl "$pipelineUrl" `
+                                                                      -ImageUrl "https://nodejs.org/static/images/logo-hexagon-card.png"
+
+  trigger_builds:
+    name: Trigger builds
+    runs-on: ubuntu-latest
+    needs: [find_new_versions, check_new_versions]
+    env:
+      TOOL_VERSIONS: ${{needs.find_new_versions.outputs.versions_output}}
+    environment: Get Available Tools Versions - Publishing Approval
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Trigger "Build Node packages" workflow
+        run:
+          ./helpers/github/run-ci-builds.ps1 -RepositoryFullName "$env:GITHUB_REPOSITORY" `
+                                             -AccessToken "${{ secrets.PERSONAL_TOKEN }}" `
+                                             -WorkflowFileName "build-node-packages.yml" `
+                                             -WorkflowDispatchRef "main" `
+                                             -ToolVersions "${{ env.TOOL_VERSIONS }}" `
+                                             -PublishReleases "true"
+
+  check_build:
+    name: Check build for failures 
+    runs-on: ubuntu-latest
+    needs: [find_new_versions, check_new_versions, trigger_builds]
+    if: failure()
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Send Slack notification if build fails
+        run: |
+          $pipelineUrl = "$env:GITHUB_SERVER_URL/$env:GITHUB_REPOSITORY/actions/runs/$env:GITHUB_RUN_ID"
+          $Message = "The build of the '${{ env.TOOL_NAME }}' detection pipeline failed :progress-error:\nLink to the pipeline: $pipelineUrl"
+          ./helpers/get-new-tool-versions/send-slack-notification.ps1 -Url "${{ secrets.SLACK_CHANNEL_URL }}" `
+                                                                      -ToolName "${{ env.TOOL_NAME }}" `
+                                                                      -Text "$Message" `
+                                                                      -ImageUrl "https://nodejs.org/static/images/logo-hexagon-card.png"


### PR DESCRIPTION
In scope of this PR we moved [get-node-versions](https://github.visualstudio.com/virtual-environments/_apps/hub/ms.vss-build-web.ci-designer-hub?pipelineId=78&branch=main&nonce=HrI45AEntd%2BxrydgtZ7MBA%3D%3D) pipeline from Azure DevOps to this repository.

Work item: actions/virtual-environments-internal#2412