### PR TITLE
Move manifest validation pipeline from Azure DevOps

### DIFF
--- a/.github/workflows/validate-manifest.yml
+++ b/.github/workflows/validate-manifest.yml
@@ -5,8 +5,10 @@ on:
     - cron:  '0 8,20 * * *'
     
    pull_request:
-    branches:
+     branches:
       - main
+     paths:
+      - 'versions-manifest.json'
 env:
   TOOL_NAME: "Node"
 defaults:

--- a/.github/workflows/validate-manifest.yml
+++ b/.github/workflows/validate-manifest.yml
@@ -1,0 +1,45 @@
+name: Validate manifest
+
+on:
+   schedule:
+    - cron:  '0 8,20 * * *'
+    
+   pull_request:
+    branches:
+      - main
+env:
+  TOOL_NAME: "Node"
+defaults:
+  run:
+    shell: pwsh
+    
+jobs:
+  validation:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v2
+      with:
+          submodules: true
+          
+    - name: Validate node-versions manifest
+      run: .\helpers\packages-generation\manifest-validator.ps1 -ManifestUrl https://raw.githubusercontent.com/actions/node-versions/main/versions-manifest.json
+
+  check_build:
+    name: Check validation for failures 
+    runs-on: ubuntu-latest
+    needs: [validation]
+    if: failure()
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Send Slack notification if validation fails
+        run: |
+          $pipelineUrl = "$env:GITHUB_SERVER_URL/$env:GITHUB_REPOSITORY/actions/runs/$env:GITHUB_RUN_ID"
+          $message = "The validation of node-versions manifest failed. \nLink to the pipeline: $pipelineUrl"
+          .\helpers\get-new-tool-versions\send-slack-notification.ps1 -Url "${{ secrets.SLACK_CHANNEL_URL }}" `
+                                                                      -ToolName "${{ env.TOOL_NAME }}" `
+                                                                      -Text "$message" `
+                                                                      -ImageUrl "https://nodejs.org/static/images/logo-hexagon-card.png"

--- a/.github/workflows/validate-manifest.yml
+++ b/.github/workflows/validate-manifest.yml
@@ -23,7 +23,7 @@ jobs:
           submodules: true
           
     - name: Validate node-versions manifest
-      run: .\helpers\packages-generation\manifest-validator.ps1 -ManifestUrl https://raw.githubusercontent.com/actions/node-versions/main/versions-manifest.json
+      run: .\helpers\packages-generation\manifest-validator.ps1 -ManifestUrl https://raw.githubusercontent.com/actions/node-versions/main/versions-manifest.json -AccessToken ${{ secrets.GITHUB_TOKEN }}
 
   check_build:
     name: Check validation for failures 


### PR DESCRIPTION
In scope of this PR we moved manifest-validation pipeline from Azure DevOps to this repository.