### PR TITLE
Add Node.js 20.11.0

### DIFF
--- a/versions-manifest.json
+++ b/versions-manifest.json
@@ -1,5 +1,9 @@
 [
   {
+    "version": "20.11.0",
+    "TODO": "Either fix the automation or manually add the rest of the properties in the object"
+  },
+  {
     "version": "20.10.0",
     "stable": true,
     "lts": "Iron",


### PR DESCRIPTION
Since there is no way to open issues here, I opened a PR for discussion instead.

[Node.js 20.11.0](https://nodejs.org/en/blog/release/v20.11.0) has been out since 10 Jan 2024, but the automated PRs have not yet updated this.

Maybe some automation is broken here? Or is there a schedule for releasing these new versions? If it is scheduled, maybe the delay from the release to the manifest being updated could be decreased?

I'm coming here because of [a failure in `actions/setup-node` to resolve `lts/*` to `20.11.0`](https://github.com/actions/setup-node/issues/940), also when using `check-latest: true`:

```
Run actions/setup-node@v4
  with:
    node-version: lts/*
    always-auth: false
    check-latest: false
    token: ***
Attempt to resolve LTS alias from manifest...
Found in cache @ /opt/hostedtoolcache/node/20.10.0/x64
Environment details
  node: v20.10.0
  npm: 10.2.3
  yarn: 1.22.21
```

cc @MaksimZhukov @dmitry-shibanov @dusan-trickovic