### PR TITLE
Implementing Runner-Specific Node.js Tests 

### DIFF
--- a/tests/Node.Tests.ps1
+++ b/tests/Node.Tests.ps1
@@ -1,20 +1,23 @@
 Import-Module (Join-Path $PSScriptRoot "../helpers/pester-extensions.psm1")
 
-BeforeAll {
-    function Get-UseNodeLogs {
-        # GitHub Windows images don't have `HOME` variable
-        $homeDir = $env:HOME ?? $env:HOMEDRIVE
-        $logsFolderPath = Join-Path -Path $homeDir -ChildPath "runners/*/_diag/pages" -Resolve
 
-        $useNodeLogFile = Get-ChildItem -Path $logsFolderPath | Where-Object {
-            $logContent = Get-Content $_.Fullname -Raw
-            return $logContent -match "setup-node@v"
-        } | Select-Object -First 1
-        return $useNodeLogFile.Fullname
-    }
-}
 
 Describe "Node.js" {
+
+    BeforeAll {
+        function Get-UseNodeLogs {
+            # GitHub Windows images don't have `HOME` variable
+            $homeDir = $env:HOME ?? $env:HOMEDRIVE
+            $logsFolderPath = Join-Path -Path $homeDir -ChildPath "runners/*/_diag/pages" -Resolve
+    
+            $useNodeLogFile = Get-ChildItem -Path $logsFolderPath | Where-Object {
+                $logContent = Get-Content $_.Fullname -Raw
+                return $logContent -match "setup-node@v"
+            } | Select-Object -First 1
+            return $useNodeLogFile.Fullname
+        }
+    }
+    
     It "is available" {
         "node --version" | Should -ReturnZeroExitCode
     }

--- a/tests/Node.Tests.ps1
+++ b/tests/Node.Tests.ps1
@@ -35,13 +35,22 @@ Describe "Node.js" {
     }
 
     It "cached version is used without downloading" {
-        # Analyze output of previous steps to check if Node.js was consumed from cache or downloaded
-        $useNodeLogFile = Get-UseNodeLogs
-        $useNodeLogFile | Should -Exist
-        $useNodeLogContent = Get-Content $useNodeLogFile -Raw
-        $useNodeLogContent | Should -Match "Found in cache"
+        if ($env:RUNNER_TYPE -eq "GitHub") {
+            # Analyze output of previous steps to check if Node.js was consumed from cache or downloaded
+            $useNodeLogFile = Get-UseNodeLogs
+            $useNodeLogFile | Should -Exist
+            $useNodeLogContent = Get-Content $useNodeLogFile -Raw
+            $useNodeLogContent | Should -Match "Found in cache"
+        } else {
+            # Get the installed version of Node.js
+            $nodeVersion = Invoke-Expression "node --version"
+            # Check if Node.js is installed
+            $nodeVersion | Should -Not -BeNullOrEmpty
+            # Check if the installed version of Node.js is the expected version
+            $nodeVersion | Should -Match $env:VERSION
+        }
     }
-
+    
     It "Run simple code" {
         "node ./simple-test.js" | Should -ReturnZeroExitCode
     }

--- a/tests/Node.Tests.ps1
+++ b/tests/Node.Tests.ps1
@@ -34,21 +34,22 @@ Describe "Node.js" {
         $nodePath.startsWith($expectedPath) | Should -BeTrue -Because "'$nodePath' is not started with '$expectedPath'"
     }
 
-    It "cached version is used without downloading" {
-        if ($env:RUNNER_TYPE -eq "GitHub") {
-            # Analyze output of previous steps to check if Node.js was consumed from cache or downloaded
-            $useNodeLogFile = Get-UseNodeLogs
-            $useNodeLogFile | Should -Exist
-            $useNodeLogContent = Get-Content $useNodeLogFile -Raw
-            $useNodeLogContent | Should -Match "Found in cache"
-        } else {
+     It "cached version is used without downloading" {
+
+       if ($env:RUNNER_TYPE -eq "self-hosted") {
             # Get the installed version of Node.js
             $nodeVersion = Invoke-Expression "node --version"
             # Check if Node.js is installed
             $nodeVersion | Should -Not -BeNullOrEmpty
             # Check if the installed version of Node.js is the expected version
             $nodeVersion | Should -Match $env:VERSION
-        }
+        }else {
+            # Analyze output of previous steps to check if Node.js was consumed from cache or downloaded
+            $useNodeLogFile = Get-UseNodeLogs
+            $useNodeLogFile | Should -Exist
+            $useNodeLogContent = Get-Content $useNodeLogFile -Raw
+            $useNodeLogContent | Should -Match "Found in cache"
+        } 
     }
     
     It "Run simple code" {


### PR DESCRIPTION
Added a test condition in 'Node.Tests.ps1' to differentiate between GitHub-hosted runners and others. This enables specific checks for cached Node.js usage in GitHub-hosted runners and version validation in other environments.